### PR TITLE
Add view-result-postprocessor

### DIFF
--- a/lib/view-result-postprocessor.rb
+++ b/lib/view-result-postprocessor.rb
@@ -1,0 +1,7 @@
+require File.join File.dirname(__FILE__), File.basename(__FILE__, '.rb'), 'extension'
+
+Asciidoctor::Extensions.register do
+  if (@document.basebackend? 'html')
+    postprocessor ViewResultPostprocessor
+  end
+end

--- a/lib/view-result-postprocessor/extension.rb
+++ b/lib/view-result-postprocessor/extension.rb
@@ -1,0 +1,67 @@
+require 'asciidoctor'
+require 'asciidoctor/extensions'
+
+# An extension that automatically hides blocks marked with the style
+# "result" and adds a link to the previous element that has the style
+# "title" that allows displaying the "result".
+#
+# Usage
+#
+#   = View Result Sample
+#
+#   .This will have a link next to it
+#   ----
+#   * always displayed
+#   * always displayed 2
+#   ----
+#
+#   [.result]
+#   ====
+#   * hidden till clicked
+#   * hidden till clicked 2
+#   ====
+#
+#
+class ViewResultPostprocessor < Asciidoctor::Extensions::Postprocessor
+  def process output
+    if @document.basebackend? 'html'
+      # Eventually we want an API (similar to docinfo hook) for adding content to the header
+      replacement = %(<style>
+.listingblock a.view-result {
+float: right;
+font-weight: normal;
+text-decoration: none;
+font-size: 0.9em;
+line-height: 1.4;
+margin-top: 0.15em;
+}
+.exampleblock.result {
+display: none;
+}
+</style>
+<script src="http://cdnjs.cloudflare.com/ajax/libs/zepto/1.1.3/zepto.min.js"></script>
+<script type="text/javascript">
+function toggle_result_block(e) {
+  this.prev().toggleClass('stacked');
+  this.toggle();
+  return false;
+}
+
+function insert_result_links() {
+  $('.result').each(function(idx, node) {
+    znode = $(node);
+    title_div = znode.prev().find('.title')
+    title_div.append('<a class="view-result" href="#">[ view result ]</a>');
+    view_result_link = title_div.children().last();
+    view_result_link.on('click', $.proxy(toggle_result_block, znode));
+  });
+}
+
+$(insert_result_links);
+</script>
+</head>)
+      output = output.sub(/<\/head>/m, replacement)
+    end
+    output
+  end
+end

--- a/lib/view-result-postprocessor/sample.adoc
+++ b/lib/view-result-postprocessor/sample.adoc
@@ -1,0 +1,13 @@
+= View Result Sample
+
+.This will have a link next to it
+----
+* always displayed
+* always displayed 2
+----
+
+[.result]
+====
+* hidden till clicked
+* hidden till clicked 2
+====


### PR DESCRIPTION
There are currently some shortcomings of this extension:
- It always adds the styling inline, but should support externalization
- It always adds the zepto JS but should check to see if it is necessary
- It always adds the JS inline, but should support externalization
- The node that has the view result link is added should be customizable
- The text to click on for the view result link should be customizable

Starts work on #1
