### PR TITLE
- Added extension ent2uni, a postprocessor which maps HTML entities to unicode

### DIFF
--- a/lib/ent2uni.rb
+++ b/lib/ent2uni.rb
@@ -1,0 +1,5 @@
+require_relative 'ent2uni/extension'
+
+Asciidoctor::Extensions.register do
+    postprocessor EntToUni
+end

--- a/lib/ent2uni/extension.rb
+++ b/lib/ent2uni/extension.rb
@@ -1,0 +1,17 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+require 'htmlentities'
+
+include ::Asciidoctor
+
+# Replaces HTML entities by their unicode equivalents
+#
+# @author James Carlson
+
+class EntToUni < Extensions::Postprocessor
+
+  def process document, output
+    decoder = HTMLEntities.new  
+    output = decoder.decode output
+  end
+  
+end

--- a/lib/ent2uni/sample.adoc
+++ b/lib/ent2uni/sample.adoc
@@ -1,0 +1,10 @@
+
+== Test: map HTML entities to unicode equivalents.
+
+Well -- he said -- this not my policy, it is the Boss's.
+
+What's that?
+
+If you are > 60 you pay half-price. _If you have your birth certicate._
+
+


### PR DESCRIPTION
The post processor maps HTML entities to their unicode equivalents.

This was needed to sanitize output from the Asciidoctor LaTeX  backend before running it through `xelatex`, but it is perhaps useful for other things as well. 

Current workflow for `.adoc` to `.tex` using the normal math convention $ a^2 + b^2 = c^2 $ is 

```
$ a2l foo.adoc
```

where

```
alias a2l="$adb/asciidoctor -r $pre -r $post -r $lco -b latex"
```

and where `$pre`, `$post`, and `$lco` point to `tex-preprocessor.rb`, `ent2uni.rb`, and `asciidoctor-latex/converter.rb`.
