### PR TITLE
Fix class name for shell-session-treeprocessor.

### DIFF
--- a/lib/shell-session-treeprocessor.rb
+++ b/lib/shell-session-treeprocessor.rb
@@ -1,5 +1,5 @@
 require_relative 'shell-session-treeprocessor/extension'
 
 Extensions.register do
-  treeprocessor TerminalCommandTreeprocessor
+  treeprocessor ShellSessionTreeprocessor
 end


### PR DESCRIPTION
The name of the class was different between two of the extension files, resulting in an exception due to the inability to find the class.
