### PR TITLE
Add a DocinfoProcessor to emit license information.

### DIFF
--- a/lib/license-url-docinfoprocessor.rb
+++ b/lib/license-url-docinfoprocessor.rb
@@ -1,0 +1,36 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include ::Asciidoctor
+
+# A postprocessor that emits an appropriate license URL into a document.
+# Requires that the license attribute contain one or more http or https URL.
+#
+# Usage
+#
+#   :license: http://opensource.org/licenses/MIT
+#
+Extensions.register do
+  docinfo_processor do
+    at_location :header
+    process do |doc|
+      next unless doc.attr? 'license'
+      backend = doc.backend
+
+      result = []
+
+      # Support dual licensing.
+      (doc.attr 'license').split(/\s+/).each do |url|
+        next unless url.start_with? 'http://', 'https://'
+        if backend == 'docbook5'
+          result << %(<dct:license xmlns:dct="http://purl.org/dc/terms/">#{url}</dct:license>)
+        elsif backend == 'html5'
+          result << %(<link rel="license" href="#{url}">)
+        elsif backend == 'xhtml5'
+          result << %(<link rel="license" href="#{url}" />)
+        end
+      end
+
+      result * EOL
+    end
+  end
+end


### PR DESCRIPTION
Often people will want to include a URL to the license for a document, and in some cases (e.g. Creative Commons licenses), it's obligatory.  This provides an extension to process a license attribute that contains an HTTP or HTTPS URL.  It doesn't handle non-URLs, because the elements in question don't support non-URLs, and it also allows one to write something like `:license: http://opensource.org/licenses/MIT or http://opensource.org/licenses/BSD-2-Clause` and have it do the right thing.

It also doesn't support DocBook 4, because DocBook 4 doesn't support embedding arbitrary elements in the *info sections.