### PR TITLE
Added extension for parsing TeX to SVG using Mathematical

### DIFF
--- a/lib/mathematical-treeprocessor/extension.rb
+++ b/lib/mathematical-treeprocessor/extension.rb
@@ -1,0 +1,38 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+require 'mathematical'
+
+include ::Asciidoctor
+
+module Asciidoctor
+class LibMathematical < Extensions::Treeprocessor
+  def process document
+    unless (stem_blocks = document.find_by context: :stem).nil_or_empty?
+      # This defaults to SVG and standard delimiters ($..$ for inline, $$..$$ for block)
+      mathematical = ::Mathematical.new
+
+      stem_blocks.each do |math|
+        equation_data = %($$#{math.content}$$)
+        equation_type = math.style.to_sym
+        # FIXME auto-generate id if one is not provided
+        if math.id
+          math_id = alt_text = math.id
+        else
+          require 'digest'
+          math_id = %(stem-#{::Digest::MD5.hexdigest math.content})
+          alt_text = 'STEM equation'
+        end
+        image_target = %(#{math_id}.svg)
+        image_file = math.normalize_system_path image_target, (math.document.attr 'imagesdir')
+
+        result = mathematical.parse(equation_data)
+        File.open(image_file, 'w') { |file| file.write(result[:data]) }
+        attrs = { 'target' => image_target, 'alt' => alt_text }
+        parent = math.parent
+        image = Block.new parent, :image, attributes: attrs
+        parent.blocks[parent.blocks.index(math)] = image
+      end
+    end
+    document
+  end
+end
+end

--- a/lib/mathematical-treeprocessor/sample.adoc
+++ b/lib/mathematical-treeprocessor/sample.adoc
@@ -1,0 +1,6 @@
+= _Precompiled_ Math!
+
+[stem#equation1]
+++++
+\left\langle {a + a \over x - a} | \epsilon_\Xi(a) \right\rangle = \left\{ \frac{1}{N} \sum_{i=0}^N \frac{x^i}{i!} + \Xi \int_0^x \epsilon_0(at) \, dt \right\}
+++++

--- a/lib/mathematical-treeprocessor/test.rb
+++ b/lib/mathematical-treeprocessor/test.rb
@@ -1,0 +1,8 @@
+require 'asciidoctor'
+require_relative 'extension'
+
+Asciidoctor::Extensions.register do
+  treeprocessor LibMathematical
+end
+
+Asciidoctor.convert_file('sample.adoc', :in_place => true)


### PR DESCRIPTION
I've experimented with [Mathematical](https://github.com/gjtorikian/mathematical), which led me to a small-footprint-solution for converting TeX equations to SVG.

For further information see https://github.com/tstumm/asciidoctor-lib-mathematical and
Issue asciidoctor/asciidoctor-pdf#45