### PR TITLE
feat: navigation icons for toc sidebar

### DIFF
--- a/lib/navigation-toc-postprocessor.rb
+++ b/lib/navigation-toc-postprocessor.rb
@@ -2,7 +2,7 @@ RUBY_ENGINE == 'opal' ? (require 'navigation-toc-postprocessor/extension') : (re
 
 Asciidoctor::Extensions.register do
   if document.basebackend? 'html' # currently only html support
-    block NavBlockProcessor
+    block_macro NavBlockMacroProcessor
     postprocessor NavigationTocPostprocessor
     docinfo_processor NavIconsDocinfoProcessor
   end

--- a/lib/navigation-toc-postprocessor.rb
+++ b/lib/navigation-toc-postprocessor.rb
@@ -1,5 +1,9 @@
 RUBY_ENGINE == 'opal' ? (require 'navigation-toc-postprocessor/extension') : (require_relative 'navigation-toc-postprocessor/extension')
 
 Asciidoctor::Extensions.register do
-  postprocessor NavigationTocPostprocessor
+  if document.basebackend? 'html' # currently only html support
+    block NavBlockProcessor
+    postprocessor NavigationTocPostprocessor
+    docinfo_processor NavIconsDocinfoProcessor
+  end
 end

--- a/lib/navigation-toc-postprocessor.rb
+++ b/lib/navigation-toc-postprocessor.rb
@@ -1,0 +1,5 @@
+RUBY_ENGINE == 'opal' ? (require 'navigation-toc-postprocessor/extension') : (require_relative 'navigation-toc-postprocessor/extension')
+
+Asciidoctor::Extensions.register do
+  postprocessor NavigationTocPostprocessor
+end

--- a/lib/navigation-toc-postprocessor/extension.rb
+++ b/lib/navigation-toc-postprocessor/extension.rb
@@ -1,0 +1,27 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+class NavigationTocPostprocessor < Asciidoctor::Extensions::Postprocessor
+  def process document, output
+    content = ""
+    if document.attr 'nav-home'
+      content << "<a href=\"#{(document.attr 'nav-home')}\"><i class=\"fa fa-home\" aria-hidden=\"true\"></i></a>&nbsp;"
+    end
+    if document.attr 'nav-prev'
+      content << "<a href=\"#{(document.attr 'nav-prev')}\"><i class=\"fa fa-arrow-left\" aria-hidden=\"true\"></i></a>&nbsp;"
+    end
+    if document.attr 'nav-up'
+      content << "<a href=\"#{(document.attr 'nav-up')}\"><i class=\"fa fa-arrow-up\" aria-hidden=\"true\"></i></a>&nbsp;"
+    end
+    if document.attr 'nav-down'
+      content << "<a href=\"#{(document.attr 'nav-down')}\"><i class=\"fa fa-arrow-down\" aria-hidden=\"true\"></i></a>&nbsp;"
+    end
+    if document.attr 'nav-next'
+      content << "<a href=\"#{(document.attr 'nav-next')}\"><i class=\"fa fa-arrow-next\" aria-hidden=\"true\"></i></a>&nbsp;"
+    end
+    if document.basebackend? 'html'
+      replacement = %(\\1<div id="toc-nav">\n#{content}</div>)
+      output = output.sub(/(<div id="toctitle".*?<\/div>)/m, replacement)
+    end
+    output
+  end
+end

--- a/lib/navigation-toc-postprocessor/extension.rb
+++ b/lib/navigation-toc-postprocessor/extension.rb
@@ -3,39 +3,132 @@ require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
 class NavigationTocPostprocessor < Asciidoctor::Extensions::Postprocessor
 
   def process document, output
-    content = ""
-    if document.attr 'nav-home'
-      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-home')}\"><i class=\"fa fa-home\" aria-hidden=\"true\"></i></a></div>"
+    if document.attr 'navicons-toc'
+      html = NavIconsBackend.gen_nav_icons(document)
+      output = NavIconsBackend.insert_at(document, output, 'toc', html)
     end
-    if document.attr 'nav-prev'
-      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-prev')}\"><i class=\"fa fa-arrow-left\" aria-hidden=\"true\"></i></a></div>"
-    end
-    if document.attr 'nav-up'
-      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-up')}\"><i class=\"fa fa-arrow-up\" aria-hidden=\"true\"></i></a></div>"
-    end
-    if document.attr 'nav-down'
-      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-down')}\"><i class=\"fa fa-arrow-down\" aria-hidden=\"true\"></i></a></div>"
-    end
-    if document.attr 'nav-next'
-      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-next')}\"><i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i></a></div>"
-    end
+    output
+  end
+end
 
-    css_replacement = %(<style>
+class NavIconsDocinfoProcessor < Asciidoctor::Extensions::DocinfoProcessor
+  # DocinfoProcessor as used in the chart-block-macro extension for adding HTML in head or footer
+  use_dsl
+  at_location :head
+
+  # inlusion of FontAwesome script, equal to the inclusion by the `:icons: font` attribute
+  FONTAWESOME_SCRIPT = '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">'
+
+  # custom stylesheet for rendering the navigation icons
+  NAVICION_STYLESHEET = %(<style>
 /*navigation-toc-postprocessor asciidoctor extension*/
-div .toc2 #toc-nav{
-  font-size: 1.6em;
-  display: flex;
-  justify-content: space-around;
-  padding-bottom: 10px;
+div #toc-nav{
+font-size: 1.6em;
+display: flex;
+justify-content: space-around;
+padding-bottom: 10px;
 }
 </style>
 </head>)
 
-    if document.basebackend? 'html'
-      nav_replacement = %(\\1<div id="toc-nav">\n#{content}</div>)
-      output = output.sub(/(<div id="toctitle".*?<\/div>)/m, nav_replacement)
-      output = output.sub(/<\/head>/m, css_replacement)
+  def process doc
+    %(
+#{FONTAWESOME_SCRIPT}
+#{NAVICION_STYLESHEET})
+  end
+
+end
+
+class NavIconsBackend
+
+  def self.gen_icon(link="", fa_name='fa-home')
+    # filter link
+    # TODO check if this is consistent with asciidoctor.rb internal handling
+    url_parse = /link\:(.*?)\[(.*?)\]/.match(link)
+    ref_parse = /<<(([^#]*?)(\.\w+?)?(#(\w*?))?)(?:,(.*?))?>>/.match(link)
+    if url_parse
+      url = url_parse[1] || ""
+      desc = url_parse[2] || nil
+    elsif ref_parse
+      url = (ref_parse[2] + '.html') || ""
+      if ref_parse[4] # add attribute link
+        url << ref_parse[4]
+      end
+      desc = ref_parse[6] || nil
+    else
+      url = link
+      desc = nil
+    end
+
+    # render HTML
+    content = "<div id=\"toc-nav-item\">"
+    icon = "<i class=\"fa #{fa_name}\" aria-hidden=\"true\"></i>"
+    if url
+      content << "<a href=\"#{url}\""
+      if desc
+        content << " title=\"#{desc}\""
+      end
+      content << ">" + icon + "</a>"
+    else
+      content << icon
+    end
+    content << "</div>"
+
+    content
+  end
+
+  def self.gen_nav_icons(document)
+    content = ""
+
+    content << self.gen_icon((document.attr 'nav-home'), 'fa-home')
+    content << self.gen_icon((document.attr 'nav-prev'), 'fa-arrow-left')
+    content << self.gen_icon((document.attr 'nav-up'),   'fa-arrow-up')
+    content << self.gen_icon((document.attr 'nav-down'), 'fa-arrow-down')
+    content << self.gen_icon((document.attr 'nav-next'), 'fa-arrow-right')
+
+    "<div id =\"toc-nav\">" + content + "</div>"
+  end
+
+  def self.insert_at(document, output, location='toc', html='nil')
+    if html
+      case location
+      when 'toc'
+        # place behind the div with id 'toctitle'
+        output = output.sub(/(<div id="toctitle".*?<\/div>)/m, %(\\1\n#{html}))
+      when 'top'
+        #TODO implement
+      when 'bottom'
+        #TODO implement
+      end
     end
     output
+  end
+end
+
+
+######
+# TODO WIP
+
+class NavBlockProcessor < Asciidoctor::Extensions::BlockProcessor
+  # TODO this is an experiment to get to a custom inline NavIcons defition like:
+  # [NAVICONS]
+  # ----
+  # nav-home link:http://asciidoctor.org[]
+  # nav-next <<post2.adoc#>>
+  # nav-prev <<post0.adoc#>>
+  # ----
+  use_dsl
+  named :NAVICONS
+  # on_context :literal
+  # name_positional_attributes 'type', 'width', 'height'
+  # parse_content_as :raw
+
+  HTML_TEST_FIXED = %(<div id="toc-nav"><div id="toc-nav-item"><a href="<<index.adoc#,test1>>"><i class="fa fa-home" aria-hidden="true"></i></a></div><div id="toc-nav-item"><a href="http://asciidoctor.org/"><i class="fa fa-arrow-left" aria-hidden="true"></i></a></div><div id="toc-nav-item"><a href="../index.html"><i class="fa fa-arrow-up" aria-hidden="true"></i></a></div><div id="toc-nav-item"><a href="http://asciidoctor.org/" title="test2"><i class="fa fa-arrow-down" aria-hidden="true"></i></a></div><div id="toc-nav-item"><a href="http://asciidoctor.org/docs/user-manual/"><i class="fa fa-arrow-right" aria-hidden="true"></i></a></div></div>)
+
+  def process(parent, reader, attrs)
+    # engine = ChartBackend.resolve_engine attrs, parent.document
+    # raw_data = PlainRubyCSV.parse(reader.source)
+    # html = ChartBackend.process engine, attrs, raw_data
+    create_pass_block parent, HTML_TEST_FIXED, attrs, subs: nil
   end
 end

--- a/lib/navigation-toc-postprocessor/extension.rb
+++ b/lib/navigation-toc-postprocessor/extension.rb
@@ -24,8 +24,9 @@ class NavigationTocPostprocessor < Asciidoctor::Extensions::Postprocessor
 /*navigation-toc-postprocessor asciidoctor extension*/
 div .toc2 #toc-nav{
   font-size: 1.6em;
-   display: flex;
-   justify-content: space-around;
+  display: flex;
+  justify-content: space-around;
+  padding-bottom: 10px;
 }
 </style>
 </head>)

--- a/lib/navigation-toc-postprocessor/extension.rb
+++ b/lib/navigation-toc-postprocessor/extension.rb
@@ -1,26 +1,39 @@
 require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
 
 class NavigationTocPostprocessor < Asciidoctor::Extensions::Postprocessor
+
   def process document, output
     content = ""
     if document.attr 'nav-home'
-      content << "<a href=\"#{(document.attr 'nav-home')}\"><i class=\"fa fa-home\" aria-hidden=\"true\"></i></a>&nbsp;"
+      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-home')}\"><i class=\"fa fa-home\" aria-hidden=\"true\"></i></a></div>"
     end
     if document.attr 'nav-prev'
-      content << "<a href=\"#{(document.attr 'nav-prev')}\"><i class=\"fa fa-arrow-left\" aria-hidden=\"true\"></i></a>&nbsp;"
+      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-prev')}\"><i class=\"fa fa-arrow-left\" aria-hidden=\"true\"></i></a></div>"
     end
     if document.attr 'nav-up'
-      content << "<a href=\"#{(document.attr 'nav-up')}\"><i class=\"fa fa-arrow-up\" aria-hidden=\"true\"></i></a>&nbsp;"
+      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-up')}\"><i class=\"fa fa-arrow-up\" aria-hidden=\"true\"></i></a></div>"
     end
     if document.attr 'nav-down'
-      content << "<a href=\"#{(document.attr 'nav-down')}\"><i class=\"fa fa-arrow-down\" aria-hidden=\"true\"></i></a>&nbsp;"
+      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-down')}\"><i class=\"fa fa-arrow-down\" aria-hidden=\"true\"></i></a></div>"
     end
     if document.attr 'nav-next'
-      content << "<a href=\"#{(document.attr 'nav-next')}\"><i class=\"fa fa-arrow-next\" aria-hidden=\"true\"></i></a>&nbsp;"
+      content << "<div id=\"toc-nav-item\"><a href=\"#{(document.attr 'nav-next')}\"><i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i></a></div>"
     end
+
+    css_replacement = %(<style>
+/*navigation-toc-postprocessor asciidoctor extension*/
+div .toc2 #toc-nav{
+  font-size: 1.6em;
+   display: flex;
+   justify-content: space-around;
+}
+</style>
+</head>)
+
     if document.basebackend? 'html'
-      replacement = %(\\1<div id="toc-nav">\n#{content}</div>)
-      output = output.sub(/(<div id="toctitle".*?<\/div>)/m, replacement)
+      nav_replacement = %(\\1<div id="toc-nav">\n#{content}</div>)
+      output = output.sub(/(<div id="toctitle".*?<\/div>)/m, nav_replacement)
+      output = output.sub(/<\/head>/m, css_replacement)
     end
     output
   end

--- a/lib/navigation-toc-postprocessor/extension.rb
+++ b/lib/navigation-toc-postprocessor/extension.rb
@@ -12,8 +12,9 @@ class NavigationTocPostprocessor < Asciidoctor::Extensions::Postprocessor
       when 'macro'
         # do nothing on this level,block macro is handled in a different stage
       end
-    output
+    output #fallback
     end
+    output #always passthrough
   end
 end
 

--- a/lib/navigation-toc-postprocessor/sample.adoc
+++ b/lib/navigation-toc-postprocessor/sample.adoc
@@ -1,20 +1,52 @@
 = Sample document
-:navicons-toc:
+:navicons:
 :toc: left
 :icons: font
-:nav-home: <<index.adoc#,test1>>
+:nav-home: <<index.adoc#,back to home>>
 :nav-up: ../index.html
-:nav-down: link:http://asciidoctor.org/[test2]
+:nav-down: link:http://asciidoctor.org/[all about asciidoctor]
 :nav-next: http://asciidoctor.org/docs/user-manual/
 :nav-prev: http://asciidoctor.org/
 
-== Header 1
-And some sample-text
+== About this plugin
 
----
-bla
 
----
-[NAVICONS]
+.Icon definitions
+[source, asciidoc]
+----
+:nav-home: <<index.adoc#,back to home>>
+:nav-up: ../index.html
+:nav-down: link:http://asciidoctor.org/[all about asciidoctor]
+:nav-next: http://asciidoctor.org/docs/user-manual/
+:nav-prev: http://asciidoctor.org/
+----
 
-NAVICONS:[]
+.Displaying navigation in the table of contents
+[source, asciidoc]
+----
+= Title
+:navicons: toc
+----
+
+.Only displaying navigation by macro
+[source, asciidoc]
+----
+= Title
+:navicons: macro
+
+nav::[]
+----
+
+And some sample-text, before triggering a manual placement.
+
+nav::[]
+
+And we can do so again.
+
+nav::[]
+
+If we set `:toc: macro` and enable navigation icons in the table of contents using `:navicons:` or `:navicons: toc` this manual placement will include the navigation icons.
+
+_the table of contents will appear here_
+
+toc::[]

--- a/lib/navigation-toc-postprocessor/sample.adoc
+++ b/lib/navigation-toc-postprocessor/sample.adoc
@@ -1,11 +1,20 @@
 = Sample document
+:navicons-toc:
 :toc: left
 :icons: font
-:nav-home: http://asciidoctor.org/
+:nav-home: <<index.adoc#,test1>>
 :nav-up: ../index.html
-:nav-down: http://asciidoctor.org/
+:nav-down: link:http://asciidoctor.org/[test2]
 :nav-next: http://asciidoctor.org/docs/user-manual/
 :nav-prev: http://asciidoctor.org/
 
 == Header 1
 And some sample-text
+
+---
+bla
+
+---
+[NAVICONS]
+
+NAVICONS:[]

--- a/lib/navigation-toc-postprocessor/sample.adoc
+++ b/lib/navigation-toc-postprocessor/sample.adoc
@@ -1,0 +1,11 @@
+= Sample document
+:toc: left
+:icons: font
+:nav-home: http://asciidoctor.org/
+:nav-up: ../index.html
+:nav-down: http://asciidoctor.org/
+:nav-next: http://asciidoctor.org/docs/user-manual/
+:nav-prev: http://asciidoctor.org/
+
+== Header 1
+And some sample-text


### PR DESCRIPTION
Icons can be invoked using `nav-home`, `nav-up`, `nav-down`, `nav-prev` and `nav-next`. It does require support for Awesomefont which can be triggered using the `icons:font` attribute.

I'm eager to receive feedback on this, as I guess it can benefit from better checking and Ruby coding style in general. It basically does what it's supposed to do, but can probably be improved.

My main inspiration for the navigation icons was the [Debian Maintainers guide](https://www.debian.org/doc/manuals/maint-guide/start.en.html)
