### PR TITLE
feat: middleman-protect-emails port

### DIFF
--- a/lib/protect-emails-postprocessor.rb
+++ b/lib/protect-emails-postprocessor.rb
@@ -1,0 +1,8 @@
+RUBY_ENGINE == 'opal' ? (require 'protect-emails-postprocessor/extension') : (require_relative 'protect-emails-postprocessor/extension')
+
+Asciidoctor::Extensions.register do
+  if document.basebackend? 'html' # currently only html support
+    postprocessor ProtectEmailsPostprocessor
+    docinfo_processor ProtectEmailsDocinfoProcessor
+  end
+end

--- a/lib/protect-emails-postprocessor/extension.rb
+++ b/lib/protect-emails-postprocessor/extension.rb
@@ -1,0 +1,47 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+# Function rewrite_response is taken from
+# https://github.com/amsardesai/middleman-protect-emails v0.4.0
+# Copyright (c) 2014 Ankit Sardesai
+# MIT license
+
+class ProtectEmailsDocinfoProcessor < Asciidoctor::Extensions::DocinfoProcessor
+  # DocinfoProcessor as used in the chart-block-macro extension for adding HTML in head or footer
+  use_dsl
+  at_location :footer # script needs to be included in the body
+
+  ROT13_SCRIPT = '<script type="text/javascript">!function(){try{var a,b,c,d,g=document.getElementsByTagName("a");for(c=0;g.length-c;c++)try{b=g[c].getAttribute("href"),b&&b.indexOf("#email-protection-")>-1&&b.length>19&&(a="",d=19+b.indexOf("#email-protection-"),b.length>d&&(a=b.substr(18).replace(/[a-zA-Z]/g,function(a){return String.fromCharCode(("Z">=a?90:122)>=(a=a.charCodeAt(0)+13)?a:a-26)})),g[c].setAttribute("href","mailto:"+a))}catch(h){}}catch(h){}}();</script>'
+
+  def process doc
+    %(#{ROT13_SCRIPT})
+  end
+end
+
+class ProtectEmailsPostprocessor < Asciidoctor::Extensions::Postprocessor
+  def process document, output
+    output = rewrite_response(output)
+  end
+
+  private
+
+  def rewrite_response(body)
+
+    # Keeps track of email replaces
+    replaced_email = false
+
+    # Replaces mailto links with ROT13 equivalent
+    # TODO: Don't replace plaintext mailto links
+    #       Please contribute upstream
+    invalid_character = '\s"\'>'
+    email_username = "[^@#{invalid_character}]+"
+    email_domain = "[^?#{invalid_character}]+"
+    email_param = "[^&#{invalid_character}]+"
+    new_content = body.gsub /mailto:(#{email_username}@#{email_domain}(\?#{email_param}(\&#{email_param})*)?)/i do
+      replaced_email = true
+      email = $1.tr 'A-Za-z','N-ZA-Mn-za-m'
+      "#email-protection-#{email}"
+    end
+
+    return new_content
+  end
+end

--- a/lib/protect-emails-postprocessor/sample.adoc
+++ b/lib/protect-emails-postprocessor/sample.adoc
@@ -1,0 +1,8 @@
+= Protecting e-mails
+
+.Basic mailto
+* link:mailto:secret_address@asciidoctor.org[link]
+
+.Complicated mailto
+* link:mailto:secret_address@asciidoctor.org?subject=plugin%20test[link with subject]
+* link:mailto:secret_address@asciidoctor.org?subject=plugin%20test&body=Testing%20e-mail[link with subject and body]


### PR DESCRIPTION
In trying to find an Asciidoctor native solution for obfuscating `mailto:` links, I came across the https://github.com/amsardesai/middleman-protect-emails project and decided to port it as an Asciidoctor extension. The source project is MIT licensed.

**Known issues:**
- plaintext `mailto:` content not intended as a link will still be replaced. _The most simple fix would be to test for the_`<a ></a>` _context, neglecting any higher levels of HTML nesting._
- Internationalization for non-ASCII characters, as mentioned in https://github.com/amsardesai/middleman-protect-emails/issues/6 _on the other hand Asciidoctor itself doesn't seem to be handling this correctly also. _Perhaps this has to do with encoding issues_

I consider expanding this obfuscation to other addresses like XMPP, or maybe certain URL's, but they are generally less prone to spamming.

Other methods of obfuscation concern the rendering, which can bring issues to the stylesheets. 