### PR TITLE
Wordpress Postprocessor

### DIFF
--- a/lib/wordpress-postprocessor.rb
+++ b/lib/wordpress-postprocessor.rb
@@ -1,0 +1,17 @@
+RUBY_ENGINE == 'opal' ? (require 'wordpress-postprocessor/extension') : (require_relative 'wordpress-postprocessor/extension')
+
+# Will generate HTML that is ready to be pasted in the Source view of a wordpress post
+
+Asciidoctor::Extensions.register do
+  # Preprocessor marks processed document as embedded
+  preprocessor do
+    process do |doc, reader|
+      # modify document options: set header_footer to false
+      doc.instance_variable_set :@options, (doc.options.merge header_footer: false)
+      nil
+    end
+  end
+
+  # Post processor will strip all div tags
+  postprocessor WordpressPostprocessor
+end

--- a/lib/wordpress-postprocessor.rb
+++ b/lib/wordpress-postprocessor.rb
@@ -1,6 +1,9 @@
 RUBY_ENGINE == 'opal' ? (require 'wordpress-postprocessor/extension') : (require_relative 'wordpress-postprocessor/extension')
 
-# Will generate HTML that is ready to be pasted in the Source view of a wordpress post
+# Generates HTML that is ready to be pasted in the Source view of a Wordpress post
+# Does two things:
+# - Renders an embedded document (same as using -s or --no-header-footer)
+# - Remove all <div> tags. Wordpress doesn't use them and they are not strictly required.
 
 Asciidoctor::Extensions.register do
   # Preprocessor marks processed document as embedded

--- a/lib/wordpress-postprocessor/extension.rb
+++ b/lib/wordpress-postprocessor/extension.rb
@@ -5,7 +5,7 @@ class WordpressPostprocessor < Asciidoctor::Extensions::Postprocessor
   def process document, output
     # get rid of all <div> and </div> tags including their attributes
     output = output.gsub(/<\/?div(.*?)>/m, "")
-    # return copy of output w/ newlines removed
+    # return copy of output w/ empty lines removed
     output.squeeze("\n")
   end 
 end

--- a/lib/wordpress-postprocessor/extension.rb
+++ b/lib/wordpress-postprocessor/extension.rb
@@ -1,0 +1,11 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+class WordpressPostprocessor < Asciidoctor::Extensions::Postprocessor
+
+  def process document, output
+    # get rid of all <div> and </div> tags including their attributes
+    output = output.gsub(/<\/?div(.*?)>/m, "")
+    # return copy of output w/ newlines removed
+    output.squeeze("\n")
+  end 
+end


### PR DESCRIPTION
Generates HTML that is ready to be pasted in the Source view of a Wordpress post.

Pretty simplistic right now.

Thanks to @mojavelinux for the guidance in passing the `header_footer` option properly!