### PR TITLE
Extended the chart module to allow Pie charts / Added pom.xml to produce jar which is usable in asciidoctor-maven-plugin

### DIFF
--- a/asciidoctorj-extensions-lab.gemspec
+++ b/asciidoctorj-extensions-lab.gemspec
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+# stub: ${artifactId} ${version} ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "${artifactId}"
+  s.version = "${version}"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.description = "${name}"
+  s.homepage = "https://github.com/asciidoctor/asciidoctor-extensions-lab"
+  s.licenses = ["MIT"]
+  s.rubygems_version = "2.4.8"
+  s.summary = "${description}"
+
+  s.installed_by_version = "2.4.8" if s.respond_to? :installed_by_version
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_development_dependency(%q<bundler>, ["~> 1.3"])
+      s.add_development_dependency(%q<rake>, [">= 0"])
+      s.add_development_dependency(%q<rspec>, [">= 0"])
+      s.add_runtime_dependency(%q<asciidoctor>, ["~> 1.5.0"])
+    else
+      s.add_dependency(%q<bundler>, ["~> 1.3"])
+      s.add_dependency(%q<rake>, [">= 0"])
+      s.add_dependency(%q<rspec>, [">= 0"])
+      s.add_dependency(%q<asciidoctor>, ["~> 1.5.0"])
+    end
+  else
+    s.add_dependency(%q<bundler>, ["~> 1.3"])
+    s.add_dependency(%q<rake>, [">= 0"])
+    s.add_dependency(%q<rspec>, [">= 0"])
+    s.add_dependency(%q<asciidoctor>, ["~> 1.5.0"])
+  end
+end

--- a/lib/chart-block-macro/extension.rb
+++ b/lib/chart-block-macro/extension.rb
@@ -83,16 +83,20 @@ class ChartBackend
     type = attrs['type']
     case engine
       when 'c3js'
-        data, labels = C3jsChartBuilder.prepare_data(raw_data)
-        (case type
-          when 'bar' then C3jsChartBuilder.bar data, labels, attrs
-          when 'line' then C3jsChartBuilder.line data, labels, attrs
-          when 'step' then C3jsChartBuilder.step data, labels, attrs
-          when 'spline' then C3jsChartBuilder.spline data, labels, attrs
-          else
-            # By default chart line
-            C3jsChartBuilder.line data, labels, attrs
-        end)
+        if type == 'pie'
+          C3jsChartBuilder.pie raw_data, attrs
+        else
+          data, labels = C3jsChartBuilder.prepare_data(raw_data)
+          (case type
+             when 'bar' then C3jsChartBuilder.bar data, labels, attrs
+             when 'line' then C3jsChartBuilder.line data, labels, attrs
+             when 'step' then C3jsChartBuilder.step data, labels, attrs
+             when 'spline' then C3jsChartBuilder.spline data, labels, attrs
+             else
+               # By default chart line
+               C3jsChartBuilder.line data, labels, attrs
+           end)
+        end
       when 'chartist'
         data, labels = ChartistChartBuilder.prepare_data(raw_data)
         (case type
@@ -142,6 +146,13 @@ class C3jsChartBuilder
     chart_id = get_chart_id
     chart_div = create_chart_div(chart_id)
     chart_generate_script = chart_spline_script(chart_id, data, labels, attrs)
+    to_html(chart_div, chart_generate_script)
+  end
+
+  def self.pie(raw_data, attrs)
+    chart_id = get_chart_id
+    chart_div = create_chart_div(chart_id)
+    chart_generate_script = chart_pie_script(chart_id, raw_data, attrs)
     to_html(chart_div, chart_generate_script)
   end
 
@@ -245,6 +256,22 @@ c3.generate({
       type: 'category',
       categories: #{labels.to_s}
     }
+  }
+});
+</script>)
+  end
+
+  def self.chart_pie_script(chart_id, raw_data, attrs)
+    chart_height = get_chart_height attrs
+    chart_width = get_chart_width attrs
+    %(
+<script type="text/javascript">
+c3.generate({
+  bindto: '##{chart_id}',
+  size: { height: #{chart_height}, width: #{chart_width} },
+  data: {
+    columns: #{raw_data.to_s},
+    type: 'pie'
   }
 });
 </script>)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.asciidoctor</groupId>
+  <artifactId>asciidoctorj-extensions-lab</artifactId>
+  <version>1.0.0</version>
+
+  <name>Asciidoctor extensions lab extension</name>
+  <description>Maven build, producing a jar that can be directly used by the asciidoctor-maven-plugin</description>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>lib</directory>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-gemspec</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${build.outputDirectory}/specifications</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}</directory>
+                  <includes>
+                    <include>*.gemspec</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <outputDirectory>${build.outputDirectory}/gems/${artifactId}-${version}/lib</outputDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
I usually build my presentations with Asciidoctor and Reveal.JS. Being a Maven Fan-Boy I usually use the asciidoctor-maven-plugin to build my presentations. For my current use-case I needed to add some charts and I was unable to find a working way to do this. So I reverse engineered the existing asciidoctor-maven-plugin extensions and created a pom.xml that produces jars that can be used the same way. 

With this all you need to do, is add a dependency to the artifact and "require" the module you want to use (in my case this was: chart-block-macro

After finishing this, I noticed that I want Pie charts and these weren't supported yet, so I added C3JS support for pie charts while I was at it.