### PR TITLE
Update google analytics tracking code

### DIFF
--- a/lib/google-analytics-postprocessor.rb
+++ b/lib/google-analytics-postprocessor.rb
@@ -23,17 +23,12 @@ Extensions.register do
         account_id = doc.attr 'google-analytics-account'
         %(#{output.rstrip.chomp('</html>').rstrip.chomp('</body>').chomp}
 <script>
-var _gaq = _gaq || [];
-_gaq.push(['_setAccount','#{account_id}']);
-_gaq.push(['_trackPageview']);
-(function() {
-  var ga = document.createElement('script');
-  ga.type = 'text/javascript';
-  ga.async = true;
-  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-  var s = document.getElementsByTagName('script')[0];
-  s.parentNode.insertBefore(ga, s);
-})();
+ (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  ga('create', '#{account_id}', 'auto');
+  ga('send', 'pageview');
 </script>
 </body>
 </html>)


### PR DESCRIPTION
This extension was inserting the older "Classic" tracking code but
Google now strongly recommend to use their "Universal Analytics" tracking code.