### PR TITLE
ImageSizingTreeprocessor for putting width and height attrs into images

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -97,6 +97,11 @@ Adds hardbreaks to the end of all non-empty lines that aren't section titles.
 HighlightTreeprocessor, link:lib/highlight-treeprocessor.rb[]::
 Highlights source blocks using the highlight command.
 
+ImageSizingTreeprocessor, link:lib/image-sizing-treeprocessor.rb[]::
+Embeds the dimensions of images and allows _either_ width or height scaling. 
+Solves the problem of the default stylesheet preventing height scaling (see related https://github.com/asciidoctor/asciidoctor/issues/1116[issue]).
+Assists with the existing problem that linking to an anchor inside a single html causes the undesirable behaviour where the page scrolls away from the anchor while the page is still rendering (see https://github.com/asciidoctor/asciidoctor/issues/820[issue]).
+
 ImplicitApidocInlineMacro, link:lib/implicit-apidoc-inline-macro.rb[]::
 Adds an inline macro for linking to the Javadoc of a class in the Java EE API.
 

--- a/lib/image-sizing-treeprocessor.rb
+++ b/lib/image-sizing-treeprocessor.rb
@@ -1,0 +1,7 @@
+RUBY_ENGINE == 'opal' ?
+  (require 'image-sizing-treeprocessor/extension') :
+  (require_relative 'image-sizing-treeprocessor/extension')
+
+Asciidoctor::Extensions.register do
+  treeprocessor ImageSizingTreeprocessor
+end

--- a/lib/image-sizing-treeprocessor/extension.rb
+++ b/lib/image-sizing-treeprocessor/extension.rb
@@ -1,0 +1,73 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+require 'fastimage'
+
+include ::Asciidoctor
+
+class ImageSizingTreeprocessor < Extensions::Treeprocessor
+  def process document
+
+    images = document.find_by context: :image
+
+    images.each do |img|
+      adjust_image img, document
+    end
+
+    # we also need to image images in a| table cells
+    # this is not very elegant...
+    tables = document.find_by context: :table
+    tables.each do |t|
+      for acell in (t.rows.body + t.rows.foot).flatten.select {|c| c.attr? 'style', :asciidoc }
+        for img in acell.inner_document.find_by context: :image
+          adjust_image img, document
+        end
+      end
+    end
+
+  end
+
+  def adjust_image(img, document)
+
+    attrs = img.attributes
+
+    # is this necessarily constant? could it be removed out of the loop or passed in?
+    basedir =  (document.attr 'outdir') || ((document.respond_to? :options) && document.options[:to_dir])
+
+    uri = img.image_uri attrs['target']
+    uri_starts = ['http://', 'https://', 'ftp://']
+    # absolute path for local files
+    if ! uri.start_with? *uri_starts
+      uri = File.join basedir, uri
+    end
+
+    width_w, height_w = nil
+
+    width_w = (attrs['2'] if attrs.key? '2') \
+                 || (attrs['width'] if attrs.key? 'width')
+
+    height_w = (attrs['3'] if attrs.key? '3') \
+                 || (attrs['height'] if attrs.key? 'height')
+
+    # this might fail due to e.g. no network connection
+    # potentially timeout parameters might be useful?
+    begin
+      width, height = FastImage.size uri
+    rescue
+      $stderr.puts('Unable to get image parameters for: ' + uri)
+      return
+    end
+
+    # this always uses the image aspect ratio and any any user input
+    # width (obviously) dominates
+    if width_w
+      attrs['width'] = width_w
+      attrs['height'] = width_w.to_f/width*height
+    elsif height_w
+      attrs['width'] = height_w.to_f/height*width
+      attrs['height'] = height_w
+    else
+      attrs['width'] = width
+      attrs['height'] = height
+    end
+
+  end
+end

--- a/lib/image-sizing-treeprocessor/sample.adoc
+++ b/lib/image-sizing-treeprocessor/sample.adoc
@@ -1,0 +1,44 @@
+= Image Scaling
+
+Imagine we have lots of images
+
+Local images would work nicely too but to prevent repo bloat we will link to them.
+
+If we open this referring to the fifth section with something like `+++sample.html#_section_5+++` 
+with and without the extension we see quite different behaviour
+
+== Section 1
+
+image::https://openclipart.org/download/275473/FireDiamond.svg[]
+
+== Section 2
+
+image::https://openclipart.org/download/284400/GlitchSimplifiedFire.svg[]
+
+== Section 3
+
+image::https://openclipart.org/download/226036/fire-maze-mobile-casino.svg[]
+
+== Section 4
+
+image::https://openclipart.org/download/223224/fire-anthropomorphism.svg[]
+
+== Section 5
+image::https://openclipart.org/download/189740/Fire-Extinguisher-Sign--Arvin61r58.svg[]
+
+
+== Section 6
+
+These guys are the same height!
+
+image::https://openclipart.org/download/275473/FireDiamond.svg[height=50]
+
+image::https://openclipart.org/download/284400/GlitchSimplifiedFire.svg[height=50]
+
+image::https://openclipart.org/download/226036/fire-maze-mobile-casino.svg[height=50]
+
+image::https://openclipart.org/download/223224/fire-anthropomorphism.svg[height=50]
+
+image::https://openclipart.org/download/189740/Fire-Extinguisher-Sign--Arvin61r58.svg[height=50]
+
+


### PR DESCRIPTION
I realised I couldn't do height scaling on an image in a table, and discovered that there were some other image handling problems (see [Issue 820](https://github.com/asciidoctor/asciidoctor/issues/820) and [Issue 1116](https://github.com/asciidoctor/asciidoctor/issues/1116)). For my money I would have said that at least being able to set the height rather than the width should be a feature of the core.

I thought for education I would attempt the Treeprocessor for image blocks using [fastimage](https://github.com/sdsykes/fastimage) as per the @mojavelinux suggestion. 

I took the approach (discussed in the above issues) that aspect ratio must be as per the image sizing and so this Treeprocessor respects the image aspect ratio and doesn't allow it to be changed. There is I guess other reasonable options.

I had difficulty figuring out how to iterate across table cells to deal with block images in asciidoc styled cells. There is quite possibly a better way but it wasn't obvious to me.

Hopefully this is closer to the desired code style as well.