### PR TITLE
new extension to privatise some blocks

### DIFF
--- a/lib/private-block.rb
+++ b/lib/private-block.rb
@@ -1,0 +1,6 @@
+RUBY_ENGINE == 'opal' ? (require 'private-block/extension') : (require_relative 'private-block/extension')
+
+Extensions.register do
+  block PrivateBlock
+end
+

--- a/lib/private-block/extension.rb
+++ b/lib/private-block/extension.rb
@@ -1,0 +1,39 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include ::Asciidoctor
+
+# An extension that show or hide private paragraph :
+#   shown if attribute is 1
+#     else hidden if attribute is 0
+#     else shown if document attribute 'show_private' is 1
+#     else hidden
+#
+# Usage
+#
+#   [private]
+#   visibility depends on :show_private: document attribute
+#
+#   [private,1]
+#   private but shown
+#
+#   [private,0]
+#   private and hidden
+#
+
+class PrivateBlock < Extensions::BlockProcessor
+
+  use_dsl
+
+  named :private
+  on_context :paragraph
+  name_positional_attributes 'show'
+  parse_content_as :simple
+
+  def process parent, reader, attrs
+    show = (attrs.delete 'show') || parent.document.attributes['show_private']
+    if show=="1"
+      create_paragraph parent, "[private] "+reader.lines.join(" "), attrs
+    end
+  end
+end
+

--- a/lib/private-block/sample.adoc
+++ b/lib/private-block/sample.adoc
@@ -1,0 +1,14 @@
+= My document title
+:show_private: 0
+
+[private]
+this text is hidden because show_private is 0
+
+The default visibility of private paragraph 
+depends on the :show_private: document attribute
+
+[private,1]
+this text is forced to be shown, because its attribute is 1
+
+[private,0]
+this text is forced to be hidden, because its attribute is 0


### PR DESCRIPTION
This is an extension to filter (or not) paragraphes tagged 'private'.

The paragraph is passed to the output stream if its attribute is 1,
  else it is filtered if its attribute is 0.

If no attribute is specified, so the document attribute 'show_private' is considered, and
    the paragraph is shown if 'show_private' attribute is 1
    else it is filtered.

Examples :

[private]
no attribute, so this paragraph is filtered depending of the global document attribute :show_private: (0->filtered, 1->not filtered)

 [private,1]
attribute is 1, so this paragraph doesn't pass to the output stream

[private,0]
attribute is 0, so this paragraph passes to the output stream





