### PR TITLE
fix missing require in showcomments

### DIFF
--- a/lib/showcomments-preprocessor.rb
+++ b/lib/showcomments-preprocessor.rb
@@ -1,4 +1,6 @@
-include ::Asciidoctor
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include Asciidoctor
 
 # A preprocessor that adds hardbreaks to the end of all lines.
 Extensions.register {


### PR DESCRIPTION
There was no proper `requires` in showcomments extension which made
it fail.

Added proper `requires` and now it works when you run (note the `-a showcomments`):

`asciidoctor -r ./lib/showcomments-preprocessor.rb -a showcomments lib/showcomments-preprocessor/sample.adoc`

fixes #82