### PR TITLE
IndexMarkup-Inline-Macro extension

### DIFF
--- a/lib/indexmarkup-inline-macro.rb
+++ b/lib/indexmarkup-inline-macro.rb
@@ -1,0 +1,8 @@
+RUBY_ENGINE == 'opal' ? (require 'indexmarkup-inline-macro/extension') : (require_relative 'indexmarkup-inline-macro/extension')
+
+Asciidoctor::Extensions.register do
+	inline_macro IndexMarkupNoteInlineMacro
+	inline_macro IndexMarkupRangeStartInlineMacro
+	inline_macro IndexMarkupRangeEndInlineMacro
+	block_macro IndexCatalogBlockMacro
+end

--- a/lib/indexmarkup-inline-macro/extension.rb
+++ b/lib/indexmarkup-inline-macro/extension.rb
@@ -1,0 +1,207 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include Asciidoctor
+
+class IndexMarkupNoteInlineMacro < Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :indexing_note
+  name_positional_attributes 'primary', 'secondary', 'tertiary'
+  
+  using_format :short  # this way, no <target> bit is required (OR EVEN ALLOWED!) in the inline-macro-notation
+  
+  def process parent, target, attrs
+	return unless (parent.document.basebackend? 'docbook')
+
+    # some positional attributes:
+    sec = (attrs.has_key? 'secondary') ? attrs['secondary'] : nil
+	tert = (attrs.has_key? 'tertiary') ? attrs['tertiary'] : nil
+	
+	# some named attributes:
+	type = nil
+	zone = nil
+	pagenum = nil
+	significance = nil
+	scope = nil
+	primary_sortas = nil
+	secondary_sortas = nil
+	tertiary_sortas = nil
+
+	sig_arr = [ 'normal', 'preferred' ]
+	sco_arr = [ 'global', 'local', 'all' ]
+	cool_string = ''
+	
+	attrs.each_key do |x|
+	  if x =~ /^type$/i
+		type = "#{attrs[$&]}"
+	  elsif x =~ /^zone$/i
+		zone = "#{attrs[$&]}"
+	  elsif x =~ /^see$/i
+	    cool_string += "<see>#{attrs[$&]}</see>"
+	  elsif x =~ /^seealso[0-9]*$/i
+	    cool_string += "<seealso>#{attrs[$&]}</seealso>"
+	  elsif x =~ /^significance$/i
+		significance = "#{attrs[$&]}".downcase
+	  elsif x =~ /^scope$/i
+		scope = "#{attrs[$&]}".downcase
+	  elsif x =~ /^primary_sortas$/i
+		primary_sortas = "#{attrs[$&]}"
+	  elsif x =~ /^secondary_sortas$/i
+		secondary_sortas = "#{attrs[$&]}"
+	  elsif x =~ /^tertiary_sortas$/i
+		tertiary_sortas = "#{attrs[$&]}"
+	  elsif x =~ /^pagenum$/i
+		pagenum = "#{attrs[$&]}"
+	  end
+	end
+	
+	zony = zone ? %( zone="#{zone}") : nil
+	typy = type ? %( type="#{type}") : nil
+	pagenumy = pagenum ? %( pagenum="#{pagenum}") : nil
+    signy = significance && (sig_arr.include? significance) ? %( significance="#{significance}") : nil
+    scopy = scope && (sco_arr.include? scope) ? %( scope="#{scope}") : nil
+	sortas_1 = primary_sortas && (attrs.has_key? 'primary') ? %( sortas="#{primary_sortas}") : nil
+	sortas_2 = secondary_sortas ? %( sortas="#{secondary_sortas}") : nil
+	sortas_3 = tertiary_sortas ? %( sortas="#{tertiary_sortas}") : nil
+	secy = sec ? %(<secondary#{sortas_2}>#{sec}</secondary>) : nil
+	terty = tert ? %(<tertiary#{sortas_3}>#{tert}</tertiary>) : nil
+
+	# The DocBook schema will complain if you put both <see> and <seealso> in the same <indexterm>. (THIS MACRO WILL LET YOU! :o
+
+	# @zone is of type IDREFS, so holds a single-whitespace- (i.e., #x20)-separated list; "so a single IndexTerm can point to multiple ranges."
+	# But then, if you're going to use @zone, NONE OF the block-ids' names you're referencing may contain ANY SPACES!!
+	# Asciidoctor's auto-generated IDs are OK!! but, if defining your own anchors (User Manual sec. 27.2), please note the rules that Asciidoctor uses when generating such (sec. 16.2; https://asciidoctor.org/docs/user-manual/#auto-generated-ids )
+
+    %(<indexterm#{typy}#{zony}#{pagenumy}#{signy}#{scopy}><primary#{sortas_1}>#{attrs['primary']}</primary>#{secy}#{terty}#{cool_string}</indexterm>)
+  
+  end
+end
+
+class IndexMarkupRangeStartInlineMacro < Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :indexing_start
+  name_positional_attributes 'primary', 'secondary', 'tertiary'
+  
+  using_format :short  # this way, no <target> bit is required (OR EVEN ALLOWED!) in the inline-macro-notation
+  
+  def process parent, target, attrs
+	return unless (parent.document.basebackend? 'docbook')
+
+    # some positional attributes:
+    sec = (attrs.has_key? 'secondary') ? attrs['secondary'] : nil
+	tert = (attrs.has_key? 'tertiary') ? attrs['tertiary'] : nil
+	
+	# some named attributes:
+	type = nil
+	id = 'phonyID_you-were-missing-a-real-one'
+	pagenum = nil
+	significance = nil
+	scope = nil
+	primary_sortas = nil
+	secondary_sortas = nil
+	tertiary_sortas = nil
+	
+	sig_arr = [ 'normal', 'preferred' ]
+	sco_arr = [ 'global', 'local', 'all' ]
+	cool_string = ''
+	
+	attrs.each_key do |x|
+	  if x =~ /^type$/i
+		type = "#{attrs[$&]}"
+	  elsif x =~ /^id$/i
+	    id = "#{attrs[$&]}"
+	  elsif x =~ /^see$/i
+	    cool_string += "<see>#{attrs[$&]}</see>"
+	  elsif x =~ /^seealso[0-9]*$/i
+	    cool_string += "<seealso>#{attrs[$&]}</seealso>"
+	  elsif x =~ /^significance$/i
+		significance = "#{attrs[$&]}".downcase
+	  elsif x =~ /^scope$/i
+		scope = "#{attrs[$&]}".downcase
+	  elsif x =~ /^primary_sortas$/i
+		primary_sortas = "#{attrs[$&]}"
+	  elsif x =~ /^secondary_sortas$/i
+		secondary_sortas = "#{attrs[$&]}"
+	  elsif x =~ /^tertiary_sortas$/i
+		tertiary_sortas = "#{attrs[$&]}"
+	  elsif x =~ /^pagenum$/i
+		pagenum = "#{attrs[$&]}"
+	  end
+	end
+	
+	idy = %( id="#{id}")
+	typy = type ? %( type="#{type}") : nil
+	pagenumy = pagenum ? %( pagenum="#{pagenum}") : nil
+    signy = significance && (sig_arr.include? significance) ? %( significance="#{significance}") : nil
+    scopy = scope && (sco_arr.include? scope) ? %( scope="#{scope}") : nil
+	sortas_1 = primary_sortas && (attrs.has_key? 'primary') ? %( sortas="#{primary_sortas}") : nil
+	sortas_2 = secondary_sortas ? %( sortas="#{secondary_sortas}") : nil
+	sortas_3 = tertiary_sortas ? %( sortas="#{tertiary_sortas}") : nil
+	secy = sec ? %(<secondary#{sortas_2}>#{sec}</secondary>) : nil
+	terty = tert ? %(<tertiary#{sortas_3}>#{tert}</tertiary>) : nil
+
+    %(<indexterm#{idy} class="startofrange"#{typy}#{pagenumy}#{signy}#{scopy}><primary#{sortas_1}>#{attrs['primary']}</primary>#{secy}#{terty}#{cool_string}</indexterm>)
+  
+  end
+end
+
+class IndexMarkupRangeEndInlineMacro < Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :indexing_end
+  
+  using_format :short  # this way, no <target> bit is required (OR EVEN ALLOWED!) in the inline-macro-notation
+  
+  def process parent, target, attrs
+	return unless (parent.document.basebackend? 'docbook')
+
+    # named attribute:
+	id = 'phonyID_you-were-missing-a-real-one'
+	
+	attrs.each_key do |x|
+	  if x =~ /^id$/i
+	    id = "#{attrs[$&]}"
+		break
+	  end
+	end	
+	
+	idy = %( startref="#{id}")
+
+    %(<indexterm#{idy} class="endofrange" />)
+  
+  end
+end
+
+
+class IndexCatalogBlockMacro < Asciidoctor::Extensions::BlockMacroProcessor
+  use_dsl
+
+  named :indexcatalog
+  name_positional_attributes 'title'
+  
+  def process parent, target, attrs
+	return unless (parent.document.basebackend? 'docbook')
+
+    # positional attribute:
+    ti = (attrs.has_key? 'title') ? attrs['title'] : nil
+	title = ti ? %(<title>#{ti}</title>) : nil
+
+	# named attribute:
+	type = nil
+	
+	attrs.each_key do |x|
+	  if x =~ /^type$/i
+		type = "#{attrs[$&]}"
+		break
+	  end
+	end
+  
+	typy = type ? %( type="#{type}") : nil
+
+    dbook = %(<index#{typy}>#{title}</index>)
+	create_pass_block parent, dbook, attrs, subs: nil
+	
+  end
+end
+

--- a/lib/indexmarkup-inline-macro/sample.adoc
+++ b/lib/indexmarkup-inline-macro/sample.adoc
@@ -1,0 +1,112 @@
+= Doing DocBook-index markup in AsciiDoc
+
+// N-dash:
+:N: pass:[&#8211;]
+// M-dash:
+:M: pass:[&#8212;]
+
+
+AsciiDoctor is the bee's knees! But let's face it: nobody wants to _overwrite_ their DocBook indexing_note:[DocBook, type= tech]indexing-markup by simply editing their AsciiDoctor manuscript and re-generating DocBook.indexing_note:[AsciiDoctor, tYpE =tech, seealso = AsciiDoc , priMARy_sortas = Asciidoctor, seeALSO20= lightweight markup languages ]
+_Heck, no:_ for that would involve the dubious pleasure of _re-doing_ that markup--in DocBook{M}__again and again!__
+
+So then, what you need{M}__really need__{M}my frabjous colleagues, is a way to write all that markup _inside your AsciiDoctor manuscript_.
+Well, little buckaroos and buckarinas, this is it!
+
+This extension lets you write--very easily{M}__all__ the kinds of indexing-markup the DocBook Duckindexing_note:[DocBook, the Duck, secoNdAry_sORTas= duck, type= interesting animals] supports.
+It doesn't get better than that!
+
+TIP: And why is it worthwhile to do such indexing-markup? Well, that would be because if AsciiDoctor is the bee's knees, well, DocBook is the cat's pajamas! "`DocBook`" in the wider sense, that is--which includes the awesome "`DocBook XSL`", and can do such awesomeness as __generating a full index, from that markup!__footnote:[However, it will not create specialized indices for you, based on `+type+`, unless you pass the XSL stylesheet a 1 (true) value for its `+index.on.type+` parameter.]
+
+So, what are we lookin`' at, with this thing? Well, it amounts to three inline macros and a block macro. For example:
+
+`+indexing_note:[DocBook, the Duck, secoNdAry_sORTas= duck, type= tech]+`
+
+To give you something concrete, here's what that inline-macro notation--crappy capitalization and all--gets converted to:
+
+`+<indexterm type="tech"><primary>DocBook</primary><secondary sortas="duck">the Duck</secondary></indexterm>+`
+
+In fact, that notation is included in a paragraph above (though, if you're using this extension and any but a DocBook backend, it won't appear in the output).indexing_note:[ Gone with the Wind, Abbot & Costello, The King of Siam         , secondary_sORTas = 'Wilma', TYPE = nonsense, primary_SORtas ="Fred",sCoPe= All ,  tertIAry_sORTas = 'Barney', seealso20= 'my jeans',seealso ='your jeans', sigNIFicance = nOrMaL, ] Here's another one that's up there:
+
+`+indexing_note:[AsciiDoctor, tYpE =tech, seealso = AsciiDoc , priMARy_sortas = Asciidoctor, seeALSO20= lightweight markup languages ]+`
+
+which gets turned into
+
+`+<indexterm type="tech"><primary sortas="Asciidoctor">AsciiDoctor</primary><seealso>AsciiDoc</seealso><seealso>lightweight markup languages</seealso></indexterm>+`
+
+A usage-note: in AsciiDoc's attribute-lists, the "positional" attributes are called that _for a reason!_ and they *must* appear *before* the named ones, lest they get renamed--or in any case, referenced--wrongly!
+
+In this macro, the first such attribute's value goes into a `+<primary>+`, the second (if any) into a `+<secondary>+`, and any third into a `+<tertiary>+`.
+That's it, that's all the index-levels you get in DocBook; and, it's all the positional attributes you get, in any of this extension's three inline macros.
+(Any others you insert will quietly be ignored.)
+
+Well, I've shown you just the `+indexing_note+` macro; so, what do the other two inline macros do?
+They're for marking the start and the end, respectively, of a "`range`", i.e. a _passage_ to index: e.g.,
+
+====
+indexing_start:[ the DocBook Duck, id= the_DocBook_duck, type= interesting animals, primary_sortas= duck]There is really so much to say about ducks. There is the DocBook duck, as a notable case in point. Some have even conjectured that this precocious bird was the inspiration for a certain SSL/TLS expert's publishing company's name. I have not been able to interview him yet, with regard to this intriguing conjecture.
+
+But no one should doubt the tenacity of this creature. There are other interesting critters, of course, such as the awe-inspiring wolpertinger.indexing_note:[wolpertinger, type= interesting animals] Which reminds me of another notable techie I should interview. Ah! There's just so much to learn about interesting animals! But I digress... this is really a passage about the DocBook Duck.indexing_end:[id=the_DocBook_duck]
+====
+
+Here's what the AsciiDoctor looks like:
+
+....
+indexing_start:[ the DocBook Duck, id= the_DocBook_duck, type= interesting animals, primary_sortas= duck]There is really so much to say about ducks. There is the DocBook duck, as a notable case in point. Some have even conjectured that this precocious bird was the inspiration for a certain SSL/TLS expert's publishing company's name. I have not been able to interview him yet, with regard to this intriguing conjecture.
+
+But no one should doubt the tenacity of this creature. There are other interesting critters, of course, such as the awe-inspiring wolpertinger.indexing_note:[wolpertinger, type= interesting animals] Which reminds me of another notable techie I should interview. Ah! There's just so much to learn about interesting animals! But I digress... this is really a passage about the DocBook Duck.indexing_end:[id=the_DocBook_duck]
+....
+
+
+The resulting DocBook is:
+
+....
+<simpara><indexterm id="the_DocBook_duck" class="startofrange" type="interesting animals"><primary sortas="duck">the DocBook Duck</primary></indexterm>There is really so much to say about ducks. There is the DocBook duck, as a notable case in point. Some have even conjectured that this precocious bird was the inspiration for a certain SSL/TLS expert&#8217;s publishing company&#8217;s name. I have not been able to interview him yet, with regard to this intriguing conjecture.</simpara>
+<simpara>But no one should doubt the tenacity of this creature. There are other interesting critters, of course, such as the awe-inspiring wolpertinger.<indexterm type="interesting animals"><primary>wolpertinger</primary></indexterm> Which reminds me of another notable techie I should interview. Ah! There&#8217;s just so much to learn about interesting animals! But I digress&#8230;&#8203; this is really a passage about the DocBook Duck.<indexterm startref="the_DocBook_duck" class="endofrange" /></simpara>
+....
+
+N.B.: The `+indexing_end+` macro-notation should specify one thing only--the ID of the `+indexing_start+` notation that marks the start of the passage being indexed.
+These ID values must match exactly, _including case,_ and must satisfy https://www.w3.org/TR/REC-xml/#NT-Name[XML's rules for "`NT-Name`" values].
+
+
+
+By the way, here's an artificial, "`everything but the kitchen sink`" sort of entry I placed inside a paragraph above--just to illustrate some other attributes available:
+
+`+indexing_note:[ Gone with the Wind, Abbot & Costello, The King of Siam         , secondary_sORTas = 'Wilma', TYPE = nonsense, primary_SORtas ="Fred",sCoPe= All ,  tertIAry_sORTas = 'Barney', seealso20= 'my jeans',seealso ='your jeans', sigNIFicance = nOrMaL, ]+`
+
+The DocBook it converts to is:
+
+`+<indexterm type="nonsense" significance="normal" scope="all"><primary sortas="Fred">Gone with the Wind</primary><secondary sortas="Wilma">Abbot &amp; Costello</secondary><tertiary sortas="Barney">The King of Siam</tertiary><seealso>my jeans</seealso><seealso>your jeans</seealso></indexterm>+`
+
+You'll have noticed that a few of our '`seealso`'-named attributes had numeric characters at the end: e.g., `+seealso20+`.
+That's because in AsciiDoctor attribute-lists, _you cannot have two named attributes with the same name._
+If you do, AsciiDoctor uses only the last value with that name.
+
+To "`unique-ify`" their attribute names within the same macro-notation instance, add a unique numerical sequence (any length) to the end of each--or, to all but one--of the `+seealso+` attributes. In this way, your `+seealso+` values will all pass through into `+<seealso>+` elements--as in the above examples.
+
+Another attribute you can have which creates an element in DocBook, is `+see+`.
+For its meaning, and that of the DocBook attributes `+type+`, `+significance+`, `+scope+`, and `+pagenum+` (all of which you can use in your list), please see the excellent DocBook text by Norman Walsh--most versions of which you can find online. (Bob Stayton's book _DocBook XSL_, now in its 4th ed., is also invaluable.)
+I will warn you, though, that if you include a `+see+` in the same indexing-markup notation where you have a `+seealso+`-type attribute, the DocBook schema will complain.footnote:[Although your _capitalization_ of the attribute-names is irrelevant, your _spelling_ them correctly is crucial. Likewise, using (and spelling correctly) any of the enumerated proper values for `+scope+` and `+significance+` is crucial. Any misspellings cause your attribute to be ignored.]footnote:[Also: if you include a `+tertiary_sortas+` attribute, but forget to include an actual tertiary positional-attribute _value_, then no `+<tertiary>+` element at all will appear in the output. The same is true of `+<secondary>+`--but NOT of `+<primary>+`, though only the bare `+<primary>+` element will appear (with no attribute).]
+
+Now, I omitted one other attribute which, in our macros, you can use only in `+indexing_note+`: that attribute is `+zone+`.
+It contains a single-space-character-separated list of XML ID-values (see above) that are each an anchor (ID) of sections or paragraphs within your AsciiDoctor manuscript (see the https://asciidoctor.org/docs/user-manual/[AsciiDoctor User Manual], sections 16.2; 27.1{N}2).
+
+When it includes `+zone+`, an `+indexing_note+` indexes, not its own location, but all the sections or paragraphs, in your manuscript, to which its `+zone+` attribute refers!
+The location of such an `+indexing_note+` itself is irrelevant to the index.footnote:[Although I've been using it throughout--and I advise you to get very familiar with it--the `+type+` attribute is optional. But any untyped index, if living alongside other, specialized ("`typed`") indices, will suck into its contents every single item that appears in _any_ of those other indices! If that's not what you want your "`General Index`" to do, then one of your index types should simply be "`general`"{M}and you should accordingly "`type`" _every instance_ of indexing-macro you have in your AsciiDoctor.]
+
+
+All the extension's inline macros should be used _within_ a paragraph. That's important: for a number of reasons, you don't want the `+indexterm+` elements to appear _between_ paragraphs. But we said there's also a block macro in this extension.
+
+Such a macro is to _create_ a block. This particular block macro is not to do indexing-markup: it's to indicate the place you want DocBook XSL to create the actual index, a.k.a. the "`index catalog`":
+
+`+indexcatalog::[Interesting Animals Index, type = "interesting animals"]+`
+
+Note that, since it's a block macro, it needs two colons, `+::+`, instead of just `+:+`.footnote:[Them danged colons are tyrannical, but they must be served! Likewise, remember to use _commas_, not semicolons or something else, to separate attributes in a list. If an attribute's value _contains_ a comma, put single- or double-quotation marks around that whole value.]
+That produces this XML:
+
+`+<index type="interesting animals"><title>Interesting Animals Index</title></index>+`
+
+
+indexcatalog::[ Index to Amazing Technologies, type = tech]
+
+indexcatalog::[Interesting Animals Index, type = interesting animals]
+


### PR DESCRIPTION
To support all the kinds of DocBook indexing-markup, in AsciiDoctor.