### PR TITLE
Create new extension: padding-counter-inline-macro

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -126,6 +126,9 @@ MultipageHtml5Converter, link:lib/multipage-html5-converter.rb[]::
 A simple converter that chunks the HTML5 output into multiple pages.
 Still far from complete.
 
+PaddingCounterInlineMacro, link:lib/padding-counter-inline-macro.rb[]::
+Adds four inline macros for doing padding-style counters--employing the wonderful String#succ! method.
+
 PassBlockMacro, link:lib/pass-block-macro.rb[]::
 Adds a pass block macro to AsciiDoc.
 

--- a/README.adoc
+++ b/README.adoc
@@ -127,7 +127,7 @@ A simple converter that chunks the HTML5 output into multiple pages.
 Still far from complete.
 
 PaddingCounterInlineMacro, link:lib/padding-counter-inline-macro.rb[]::
-Adds four inline macros for doing padding-style counters--employing the wonderful String#succ! method.
+Adds four inline macros for doing padding-style counters--using Ruby's wonderful String#succ! method.
 
 PassBlockMacro, link:lib/pass-block-macro.rb[]::
 Adds a pass block macro to AsciiDoc.

--- a/lib/padding-counter-inline-macro.rb
+++ b/lib/padding-counter-inline-macro.rb
@@ -1,0 +1,9 @@
+RUBY_ENGINE == 'opal' ? (require 'padding-counter-inline-macro/extension') : (require_relative 'padding-counter-inline-macro/extension')
+
+
+Asciidoctor::Extensions.register do
+	inline_macro PadCounterInlineMacro
+	inline_macro PadCounterIncrementInlineMacro
+	inline_macro PadCounterDisplayInlineMacro
+	inline_macro PadCounterConfigureInlineMacro
+end

--- a/lib/padding-counter-inline-macro/extension.rb
+++ b/lib/padding-counter-inline-macro/extension.rb
@@ -15,22 +15,22 @@ class PadCounterInlineMacro < Extensions::InlineMacroProcessor
   def process parent, target, attrs  
     
     value = nil
-		
-	attrs.each_key do |x|
-	  if x =~ /^value$/i
-		value = "#{attrs[$&]}"
-	    $pad_counter_values["#{target}"] = value
+        
+    attrs.each_key do |x|
+      if x =~ /^value$/i
+        value = "#{attrs[$&]}"
+        $pad_counter_values["#{target}"] = value
         return value
-	  end
-	end
+      end
+    end
 
     unless $pad_counter_values["#{target}"]
       $pad_counter_values["#{target}"] = $pad_counter_default
-	  return $pad_counter_default
-	else
-	  return $pad_counter_values["#{target}"].succ!
-	end
-	
+      return $pad_counter_default
+    else
+      return $pad_counter_values["#{target}"].succ!
+    end
+    
   end
 end
 
@@ -41,10 +41,10 @@ class PadCounterIncrementInlineMacro < Extensions::InlineMacroProcessor
   named :incr_cntr
 
   def process parent, target, attrs  
-	
-	$pad_counter_values["#{target}"].succ!
+    
+    $pad_counter_values["#{target}"].succ!
 
-	return nil
+    return nil
 
   end
 end
@@ -57,8 +57,8 @@ class PadCounterDisplayInlineMacro < Extensions::InlineMacroProcessor
 
   def process parent, target, attrs
   
-	return $pad_counter_values["#{target}"]
-	
+    return $pad_counter_values["#{target}"]
+    
   end
 end
 
@@ -72,15 +72,15 @@ class PadCounterConfigureInlineMacro < Extensions::InlineMacroProcessor
 
   def process parent, target, attrs 
 
-  	attrs.each_key do |x|
-	  if x =~ /^default$/i
-		$pad_counter_default = "#{attrs[$&]}"
+    attrs.each_key do |x|
+      if x =~ /^default$/i
+        $pad_counter_default = "#{attrs[$&]}"
         break
-	  end
+      end
     end
-	
-	return nil
-	
+    
+    return nil
+    
   end
 end
 

--- a/lib/padding-counter-inline-macro/extension.rb
+++ b/lib/padding-counter-inline-macro/extension.rb
@@ -72,17 +72,12 @@ class PadCounterConfigureInlineMacro < Extensions::InlineMacroProcessor
 
   def process parent, target, attrs 
 
-    default = nil
-		
-	attrs.each_key do |x|
+  	attrs.each_key do |x|
 	  if x =~ /^default$/i
-		default = "#{attrs[$&]}"
-        if default.to_i != 0 && default =~ /^[0-9]+/
-	      $pad_counter_default = $&
-	    end
-		break
+		$pad_counter_default = "#{attrs[$&]}"
+        break
 	  end
-	end
+    end
 	
 	return nil
 	

--- a/lib/padding-counter-inline-macro/extension.rb
+++ b/lib/padding-counter-inline-macro/extension.rb
@@ -18,17 +18,17 @@ class PadCounterInlineMacro < Extensions::InlineMacroProcessor
         
     attrs.each_key do |x|
       if x =~ /^value$/i
-        value = "#{attrs[$&]}"
-        $pad_counter_values["#{target}"] = value
+        value = attrs[$&]
+        $pad_counter_values[target] = value
         return value
       end
     end
 
-    unless $pad_counter_values["#{target}"]
-      $pad_counter_values["#{target}"] = $pad_counter_default
+    unless $pad_counter_values[target]
+      $pad_counter_values[target] = $pad_counter_default
       return $pad_counter_default
     else
-      return $pad_counter_values["#{target}"].succ!
+      return $pad_counter_values[target].succ!
     end
     
   end
@@ -42,7 +42,7 @@ class PadCounterIncrementInlineMacro < Extensions::InlineMacroProcessor
 
   def process parent, target, attrs  
     
-    $pad_counter_values["#{target}"].succ!
+    $pad_counter_values[target].succ!
 
     return nil
 
@@ -57,7 +57,7 @@ class PadCounterDisplayInlineMacro < Extensions::InlineMacroProcessor
 
   def process parent, target, attrs
   
-    return $pad_counter_values["#{target}"]
+    return $pad_counter_values[target]
     
   end
 end
@@ -74,7 +74,7 @@ class PadCounterConfigureInlineMacro < Extensions::InlineMacroProcessor
 
     attrs.each_key do |x|
       if x =~ /^default$/i
-        $pad_counter_default = "#{attrs[$&]}"
+        $pad_counter_default = attrs[$&]
         break
       end
     end

--- a/lib/padding-counter-inline-macro/extension.rb
+++ b/lib/padding-counter-inline-macro/extension.rb
@@ -80,6 +80,7 @@ class PadCounterConfigureInlineMacro < Extensions::InlineMacroProcessor
         if default.to_i != 0 && default =~ /^[0-9]+/
 	      $pad_counter_default = $&
 	    end
+		break
 	  end
 	end
 	

--- a/lib/padding-counter-inline-macro/extension.rb
+++ b/lib/padding-counter-inline-macro/extension.rb
@@ -1,0 +1,90 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include Asciidoctor
+
+
+$pad_counter_values = {}
+$pad_counter_default = '1'
+
+
+class PadCounterInlineMacro < Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :counter
+
+  def process parent, target, attrs  
+    
+    value = nil
+		
+	attrs.each_key do |x|
+	  if x =~ /^value$/i
+		value = "#{attrs[$&]}"
+	    $pad_counter_values["#{target}"] = value
+        return value
+	  end
+	end
+
+    unless $pad_counter_values["#{target}"]
+      $pad_counter_values["#{target}"] = $pad_counter_default
+	  return $pad_counter_default
+	else
+	  return $pad_counter_values["#{target}"].succ!
+	end
+	
+  end
+end
+
+
+class PadCounterIncrementInlineMacro < Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :incr_cntr
+
+  def process parent, target, attrs  
+	
+	$pad_counter_values["#{target}"].succ!
+
+	return nil
+
+  end
+end
+
+
+class PadCounterDisplayInlineMacro < Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :disp_cntr
+
+  def process parent, target, attrs
+  
+	return $pad_counter_values["#{target}"]
+	
+  end
+end
+
+
+class PadCounterConfigureInlineMacro < Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :conf_cntrs
+  
+  using_format :short  # this way, no <target> bit is required--OR EVEN ALLOWED!--in the inline-macro-notation
+
+  def process parent, target, attrs 
+
+    default = nil
+		
+	attrs.each_key do |x|
+	  if x =~ /^default$/i
+		default = "#{attrs[$&]}"
+        if default.to_i != 0 && default =~ /^[0-9]+/
+	      $pad_counter_default = $&
+	    end
+	  end
+	end
+	
+	return nil
+	
+  end
+end
+

--- a/lib/padding-counter-inline-macro/sample.adoc
+++ b/lib/padding-counter-inline-macro/sample.adoc
@@ -1,0 +1,19 @@
+= A counter that does padding
+
+conf_cntrs:[ default =081xx ]
+
+. XXX-counter:seq1[]
+
+. XXX-counter:seq1[value = AAA ]
+. XXX-disp_cntr:seq1[]
+
+. incr_cntr:seq1[]XXX-disp_cntr:seq1[]
+. XXX-counter:seq1[]
+. XXX-disp_cntr:seq1[]
+
+. YYY-counter:seq2[]
+. YYY-counter:seq2[]
+. YYY-counter:seq2[VALUE = 0099]
+
+. YYY-counter:seq2[]
+

--- a/lib/padding-counter-inline-macro/sample.adoc
+++ b/lib/padding-counter-inline-macro/sample.adoc
@@ -1,6 +1,6 @@
 = A counter that does padding
 
-conf_cntrs:[ default =081xx ]
+conf_cntrs:[ default =081 ]
 
 . XXX-counter:seq1[]
 


### PR DESCRIPTION
To create an extension that utilizes Ruby's amazing String#succ! method, and supports therefore 'padding'-style counters--or just about any style you can think of. This was in response to, and inspired by, the AsciiDoctor discussion-topic at http://discuss.asciidoctor.org/Counters-with-Zero-Padding-td6267.html