### PR TITLE
Create section-numbers-tree-processor extension

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -136,7 +136,7 @@ PullquoteInlineMacro, link:lib/pullquote-inline-macro.rb[]::
 Adds an inline macro to pull a quote out of the flow and display it in a sidebar.
 
 SectionNumbersTreeProcessor, link:lib/section-numbers-tree-processor.rb[]::
-Empowers your sectnums, sectnumlevels, and leveloffset attributes for conversions to DocBook.
+Empowers your AsciiDoc sectnums, sectnumlevels, and leveloffset attributes for conversions to DocBook.
 
 SectnumoffsetTreeprocessor, link:lib/sectnumoffset-treeprocessor.rb[]::
 Increments all level-1 section numbers (and subsequently all subsections) by the value of the `sectnumoffset` attribute.

--- a/README.adoc
+++ b/README.adoc
@@ -136,7 +136,7 @@ PullquoteInlineMacro, link:lib/pullquote-inline-macro.rb[]::
 Adds an inline macro to pull a quote out of the flow and display it in a sidebar.
 
 SectionNumbersTreeProcessor, link:lib/section-numbers-tree-processor.rb[]::
-Activates your sectnums (and :sectnums!:) and leveloffset Asciidoc attributes when converting to DocBook.
+Empowers your sectnums, sectnumlevels, and leveloffset attributes for conversions to DocBook.
 
 SectnumoffsetTreeprocessor, link:lib/sectnumoffset-treeprocessor.rb[]::
 Increments all level-1 section numbers (and subsequently all subsections) by the value of the `sectnumoffset` attribute.

--- a/README.adoc
+++ b/README.adoc
@@ -135,6 +135,9 @@ Adds an inline macro for selecting between two values based on the value of anot
 PullquoteInlineMacro, link:lib/pullquote-inline-macro.rb[]::
 Adds an inline macro to pull a quote out of the flow and display it in a sidebar.
 
+SectionNumbersTreeProcessor, link:lib/section-numbers-tree-processor.rb[]::
+Activates your sectnums (and :sectnums!:) and leveloffset Asciidoc attributes when converting to DocBook.
+
 SectnumoffsetTreeprocessor, link:lib/sectnumoffset-treeprocessor.rb[]::
 Increments all level-1 section numbers (and subsequently all subsections) by the value of the `sectnumoffset` attribute.
 

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -1,0 +1,5 @@
+RUBY_ENGINE == 'opal' ? (require 'section-numbers-tree-processor/extension') : (require_relative 'section-numbers-tree-processor/extension')
+
+Asciidoctor::Extensions.register do
+  treeprocessor SectionNumbersTreeProcessor
+end

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -13,7 +13,7 @@ If using asciidoctor-fopub, I'd set the XSL parameter 'section.autolabel' to 0 a
     But in asciidoctor-fopub, whether these are 1 or 0 by default DEPENDS, on whether the :sectnums: attribute was unset in your AsciiDoc header metadata:
 	
     they default to 1 IF the <?asciidoc-numbered?> XML processing-instruction is present in the DocBook XML file; and 
-    that <?asciidoc-numbered?> XML processing-instruction will be present UNLESS :sectnums: was unset in your AsciiDoc document's header metadata.
+    that <?asciidoc-numbered?> processing-instruction will be present UNLESS :sectnums: was unset in your AsciiDoc document's header metadata.
    
 (For how to pass XSL stylesheet parameters when using asciidoctor-fopub, please see https://github.com/asciidoctor/asciidoctor-fopub#custom-xsl-parameters.)
    

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -1,5 +1,15 @@
 RUBY_ENGINE == 'opal' ? (require 'section-numbers-tree-processor/extension') : (require_relative 'section-numbers-tree-processor/extension')
 
+=begin
+
+With this extension, you can control all your chapter- and section-numbering for DocBook output the same way you control it for the HTML5 backend: namely, by using the :sectnums:, :leveloffset:, :sectnumlevels:, and :doctype: attributes.
+
+I would STRONGLY advise, that after using this extension in your to-DocBook conversion, then when using asciidoctor-fopub or (otherwise) a DocBook XSL stylesheet on your XML, set the XSL stylesheet parameter 'chapter.autolabel' to 0. (It is 1 by default--whereas section.autolabel is 0 by default.) That will disable the XSL's chapter-numbering, which is superfluous when using this extension.
+
+Please note that there are several configuration variables at the top of the accompanying extension.rb file, that you can set to control how the extension does the numbering.
+
+=end
+
 Asciidoctor::Extensions.register do
   treeprocessor SectionNumbersTreeProcessor
 end

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -14,8 +14,12 @@ If using asciidoctor-fopub, I'd set the XSL parameter 'section.autolabel' to 0 a
 
     they default to 1 IF the <?asciidoc-numbered?> XML processing-instruction is present in the DocBook XML file; and 
     that processing-instruction will be present UNLESS :sectnums: was unset in your AsciiDoc document's header metadata.
+    
+    (Note: That customization is in the asciidoctor-fopub\build\fopub\docbook-xsl\common.xsl file.)
 
-(For how to pass XSL stylesheet parameters when using asciidoctor-fopub, please see https://github.com/asciidoctor/asciidoctor-fopub#custom-xsl-parameters.)
+Likewise, when using asciidoctor-fopub I'd set the 'appendix.autolabel' parameter to 0.
+
+(For how to pass XSL stylesheet parameters when using asciidoctor-fopub, please see https://github.com/asciidoctor/asciidoctor-fopub#custom-xsl-parameters . )
 
 Please note that there are several configuration variables at the top of the accompanying extension.rb file, that you can set to control how the extension does the numbering.
 

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -15,6 +15,8 @@ If using asciidoctor-fopub, I'd set the XSL parameter 'section.autolabel' to 0 a
     they default to 1 IF the <?asciidoc-numbered?> XML processing-instruction is present in the DocBook XML file; and 
     that <?asciidoc-numbered?> XML processing-instruction will be present UNLESS :sectnums: was unset in your AsciiDoc document's header metadata.
    
+(For how to pass XSL stylesheet parameters when using asciidoctor-fopub, please see https://github.com/asciidoctor/asciidoctor-fopub#custom-xsl-parameters.)
+   
 Please note that there are several configuration variables at the top of the accompanying extension.rb file, that you can set to control how the extension does the numbering.
 
 =end

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -9,14 +9,14 @@ I would strongly advise that, after using this extension in your to-DocBook conv
 If using asciidoctor-fopub, I'd set the XSL parameter 'section.autolabel' to 0 also. Here's why, if you're interested:
 
     In the standard DocBook XSL stylesheets, chapter.autolabel is 1 by default, whereas section.autolabel is 0 by default.
- 
+
     But in asciidoctor-fopub, whether these are 1 or 0 by default DEPENDS, on whether the :sectnums: attribute was unset in your AsciiDoc header metadata:
-	
+
     they default to 1 IF the <?asciidoc-numbered?> XML processing-instruction is present in the DocBook XML file; and 
     that processing-instruction will be present UNLESS :sectnums: was unset in your AsciiDoc document's header metadata.
-   
+
 (For how to pass XSL stylesheet parameters when using asciidoctor-fopub, please see https://github.com/asciidoctor/asciidoctor-fopub#custom-xsl-parameters.)
-   
+
 Please note that there are several configuration variables at the top of the accompanying extension.rb file, that you can set to control how the extension does the numbering.
 
 =end

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -4,8 +4,17 @@ RUBY_ENGINE == 'opal' ? (require 'section-numbers-tree-processor/extension') : (
 
 With this extension, you can control all your chapter- and section-numbering for DocBook output the same way you control it for the HTML5 backend: namely, by using the :sectnums:, :leveloffset:, :sectnumlevels:, and :doctype: attributes.
 
-I would STRONGLY advise, that after using this extension in your to-DocBook conversion, then when using asciidoctor-fopub or (otherwise) a DocBook XSL stylesheet on your XML, set the XSL stylesheet parameter 'chapter.autolabel' to 0. (It is 1 by default--whereas section.autolabel is 0 by default.) That will disable the XSL's chapter-numbering, which is superfluous when using this extension.
+I would strongly advise that, after using this extension in your to-DocBook conversion, then when using asciidoctor-fopub or (otherwise) a DocBook XSL stylesheet on your XML, you set the XSL stylesheet parameter 'chapter.autolabel' to 0. That will disable the XSL's chapter-numbering, which is superfluous when using this extension.
 
+If using asciidoctor-fopub, I'd set the XSL parameter 'section.autolabel' to 0 also. Here's why, if you're interested:
+
+    In the standard DocBook XSL stylesheets, chapter.autolabel is 1 by default, whereas section.autolabel is 0 by default.
+ 
+    But in asciidoctor-fopub, whether these are 1 or 0 by default DEPENDS, on whether the :sectnums: attribute was unset in your AsciiDoc header metadata:
+	
+    they default to 1 IF the <?asciidoc-numbered?> XML processing-instruction is present in the DocBook XML file; and 
+    that <?asciidoc-numbered?> XML processing-instruction will be present UNLESS :sectnums: was unset in your AsciiDoc document's header metadata.
+   
 Please note that there are several configuration variables at the top of the accompanying extension.rb file, that you can set to control how the extension does the numbering.
 
 =end

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -13,7 +13,7 @@ If using asciidoctor-fopub, I'd set the XSL parameter 'section.autolabel' to 0 a
     But in asciidoctor-fopub, whether these are 1 or 0 by default DEPENDS, on whether the :sectnums: attribute was unset in your AsciiDoc header metadata:
 	
     they default to 1 IF the <?asciidoc-numbered?> XML processing-instruction is present in the DocBook XML file; and 
-    that <?asciidoc-numbered?> processing-instruction will be present UNLESS :sectnums: was unset in your AsciiDoc document's header metadata.
+    that processing-instruction will be present UNLESS :sectnums: was unset in your AsciiDoc document's header metadata.
    
 (For how to pass XSL stylesheet parameters when using asciidoctor-fopub, please see https://github.com/asciidoctor/asciidoctor-fopub#custom-xsl-parameters.)
    

--- a/lib/section-numbers-tree-processor.rb
+++ b/lib/section-numbers-tree-processor.rb
@@ -4,7 +4,7 @@ RUBY_ENGINE == 'opal' ? (require 'section-numbers-tree-processor/extension') : (
 
 With this extension, you can control all your chapter- and section-numbering for DocBook output the same way you control it for the HTML5 backend: namely, by using the :sectnums:, :leveloffset:, :sectnumlevels:, and :doctype: attributes.
 
-I would strongly advise that, after using this extension in your to-DocBook conversion, then when using asciidoctor-fopub or (otherwise) a DocBook XSL stylesheet on your XML, you set the XSL stylesheet parameter 'chapter.autolabel' to 0. That will disable the XSL's chapter-numbering, which is superfluous when using this extension.
+I would strongly advise that, after using this extension in your to-DocBook conversion, then when using asciidoctor-fopub or (otherwise) the DocBook XSL stylesheets on your XML, you set the XSL stylesheet parameter 'chapter.autolabel' to 0. That will disable the XSL's chapter-numbering, which is superfluous when using this extension.
 
 If using asciidoctor-fopub, I'd set the XSL parameter 'section.autolabel' to 0 also. Here's why, if you're interested:
 
@@ -17,7 +17,7 @@ If using asciidoctor-fopub, I'd set the XSL parameter 'section.autolabel' to 0 a
     
     (Note: That customization is in the asciidoctor-fopub\build\fopub\docbook-xsl\common.xsl file.)
 
-Likewise, when using asciidoctor-fopub I'd set the 'appendix.autolabel' parameter to 0.
+Likewise, when using asciidoctor-fopub or (otherwise) DocBook XSL stylesheets, I'd set the 'appendix.autolabel' parameter to 0.
 
 (For how to pass XSL stylesheet parameters when using asciidoctor-fopub, please see https://github.com/asciidoctor/asciidoctor-fopub#custom-xsl-parameters . )
 

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -6,7 +6,8 @@ include Asciidoctor
 
 $punct_sntp = '.'         # punctuation between levels' numbers: e.g., '.' yields '1.3.2'
 $nr_suffix_sntp = '. '    # punctuation after the number and before the chapter's/section's title
-$chap_nums_sntp = true    # enables/disables chapter-numbering
+$chap_nums_sntp = true    # enables/disables chapter-labeling
+$chap_nr_in_sec_nr_sntp = true   # in book, starts sec-labels' nrs with chapter's number (whether or not chap-labeling enabled)
 $chap_nr_prefix_sntp = 'Chapter '
 $sec_nr_prefix_sntp = ''
 # The style you want at each level (first level is chapters; each level's style must be 'A', 'a', or '1'; add more if you need):
@@ -52,8 +53,9 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
       $levels_arr_sntp[block.level.to_i - 1] = convert_block_nr block.number, block.level.to_i
       pref = (dtype && dtype == 'book' && block.level.to_i == 1) ? $chap_nr_prefix_sntp : \
           ( block.level.to_i > 0 ? $sec_nr_prefix_sntp : '')
-      str = pref + $levels_arr_sntp[0]
-      for i in 1..(block.level.to_i - 1)
+      level_to_start = (dtype && dtype == 'book' && block.level.to_i > 1 && !$chap_nr_in_sec_nr_sntp) ? 2 : 1
+      str = pref + $levels_arr_sntp[level_to_start - 1]
+      for i in level_to_start..(block.level.to_i - 1)
         str += "#{$punct_sntp}#{$levels_arr_sntp[i]}"
       end
       str += $nr_suffix_sntp

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -6,8 +6,9 @@ include Asciidoctor
 
 $punct = '.'
 $nr_suffix = '. '
-$nr_prefix = ''
+$sec_nr_prefix = ''
 $chap_nums = false
+$chap_nr_prefix = 'Chap. '
 
 # DON'T mess with these values:
 
@@ -47,12 +48,14 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
       end
       $level_previous = block.level.to_i
       $levels_arr[block.level.to_i - 1] = block.number.to_s
-      str = $nr_prefix + $levels_arr[0]
+      pref = (dtype && dtype == 'book' && block.level.to_i == 1) ? $chap_nr_prefix : \
+          ( block.level.to_i > 0 ? $sec_nr_prefix : '')
+      str = pref + $levels_arr[0]
       for i in 1..(block.level.to_i - 1)
         str += "#{$punct}#{$levels_arr[i]}"
       end
       str += $nr_suffix
-      if ($chap_nums || !dtype || dtype != 'book' || block.level.to_i > 1)
+      if ($chap_nums || !dtype || dtype != 'book' || block.level.to_i != 1)
         str
       else
         ''

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -4,11 +4,11 @@ include Asciidoctor
 
 # Mess with these values to your heart's content:
 
-$punct = '.'
-$nr_suffix = '. '
-$sec_nr_prefix = ''
-$chap_nums = true
+$punct = '.'         # punctuation between levels' numbers: e.g., '.' yields '1.3.2'
+$nr_suffix = '. '    # punctuation after the number and before the chapter's/section's title
+$chap_nums = true    # enables/disables chapter-numbering
 $chap_nr_prefix = 'Chapter '
+$sec_nr_prefix = ''
 
 # DON'T mess with these values:
 

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -7,8 +7,8 @@ include Asciidoctor
 $punct = '.'
 $nr_suffix = '. '
 $sec_nr_prefix = ''
-$chap_nums = false
-$chap_nr_prefix = 'Chap. '
+$chap_nums = true
+$chap_nr_prefix = 'Chapter '
 
 # DON'T mess with these values:
 
@@ -55,11 +55,7 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
         str += "#{$punct}#{$levels_arr[i]}"
       end
       str += $nr_suffix
-      if ($chap_nums || !dtype || dtype != 'book' || block.level.to_i != 1)
-        str
-      else
-        ''
-      end
+      ($chap_nums || !dtype || dtype != 'book' || block.level.to_i != 1) ? str : ''
     else
       nil
     end

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -17,7 +17,7 @@ $appx_nr_prefix_sntp = 'Appendix '
 $sec_nr_prefix_sntp = ''
 # The style you want at each level (level 0 is PARTS, 1 CHAPS; set styles to 'A','a','I','i', or '1'; add levels if you need to):
 $styles_arr_sntp = [ 'I', '1', '1', '1', '1', '1', '1', '1', '1', '1' ]
-$styles_appendix_sntp = [ 'I', 'A', '1', '1', '1', '1', '1', '1', '1', '1' ]  # Styles for appx's; level 0 has no effect here
+$styles_appendix_sntp = [ 'I', 'A', '1', '1', '1', '1', '1', '1', '1', '1' ]  # Styles for appendices
 
 # DON'T mess with these values:
 

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -34,7 +34,7 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   def process_blocks node, levels, dtype
     node.blocks.each do |block|
       if block.context == :section && (defined? block.title)
-        block.title = "#{concat_sec_nr block, levels, dtype}#{block.title}"
+        block.title.replace "#{concat_sec_nr block, levels, dtype}#{block.title}"
         process_blocks block, levels, dtype if block.blocks?
         nil
       end

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -13,9 +13,11 @@ $part_nr_in_chap_nr_sntp = false  # in book, starts chap.-labels' nrs with part'
 $part_nr_in_sec_nr_sntp = true # comes into play only if $part_nr_in_chap_nr_sntp = true AND $chap_nr_in_sec_nr_sntp = true
 $part_nr_prefix_sntp = 'Part '
 $chap_nr_prefix_sntp = 'Chapter '
+$appx_nr_prefix_sntp = 'Appendix '
 $sec_nr_prefix_sntp = ''
 # The style you want at each level (level 0 is PARTS, 1 CHAPS; set styles to 'A','a','I','i', or '1'; add levels if you need to):
 $styles_arr_sntp = [ 'I', '1', '1', '1', '1', '1', '1', '1', '1', '1' ]
+$styles_appendix_sntp = [ 'I', 'A', '1', '1', '1', '1', '1', '1', '1', '1' ]  # Styles for appx's; level 0 has no effect here
 
 # DON'T mess with these values:
 
@@ -43,23 +45,28 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
 
   def concat_sec_nr block, levels, dtype
     if block.numbered && (defined? block.level) && (!(levels) || block.level.to_i <= levels.to_i)
+      styles_arr = ( block.sectname == 'appendix' ? $styles_appendix_sntp : $styles_arr_sntp )
+      part_nums = ( block.sectname == 'appendix' ? false : $part_nums_sntp )
+      # Just in case levels_arr_sntp needs lengthening for this block:
       if block.level.to_i >= $levels_arr_sntp.length
         for i in ($levels_arr_sntp.length - 1)..block.level.to_i
           $levels_arr_sntp.push '0'
         end
       end
+      # Just in case someone has, in sequence, (wrongly) jumped two, rather than one level deeper
       if block.level.to_i > $level_previous_sntp + 1
         for i in ($level_previous_sntp + 1)..(block.level.to_i - 1)
-          $levels_arr_sntp[i] = $styles_arr_sntp[i]
+          $levels_arr_sntp[i] = styles_arr[i]
         end
       end
       $level_previous_sntp = block.level.to_i
-      # Get your block.number converted:
-      $levels_arr_sntp[block.level.to_i] = convert_block_nr block.number, block.level.to_i 
+      # Convert the block.number to the style you specified for this level; and store it in levels_arr_sntp[block.level.to_i] :
+      $levels_arr_sntp[block.level.to_i] = convert_block_nr block.number.to_s.tr('A-I', '1-9').to_i, block.level.to_i, styles_arr
       # Apply any appropriate prefix:
       pref = (dtype && dtype == 'book' && block.level.to_i == 1) ? $chap_nr_prefix_sntp : \
           ( (dtype && dtype == 'book' && block.level.to_i == 0) ? $part_nr_prefix_sntp : \
           ( block.level.to_i > 0 ? $sec_nr_prefix_sntp : ''))
+      pref = ( block.sectname == 'appendix' ? $appx_nr_prefix_sntp : pref )
       # When doctype='book', must check whether level-1 nrs belong in (the true) sec.nrs--or, level-0 nrs belong in the chap.nrs:
       if (dtype && dtype == 'book')
         if block.level.to_i > 1
@@ -72,6 +79,7 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
       else
         level_to_start = 1
       end
+      # Compose the number-string:
       str = pref + $levels_arr_sntp[level_to_start]
       for i in (level_to_start + 1)..block.level.to_i
         str += "#{$punct_sntp}#{$levels_arr_sntp[i]}"
@@ -79,14 +87,14 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
       str += $nr_suffix_sntp
       #  When doctype='book', must check whether chap-nrs are enabled--and, whether part-nrs are enabled--and what level ur at:
       dtype && dtype =='book'&& \
-         ((block.level.to_i == 1 && !$chap_nums_sntp) || (block.level.to_i == 0 && !$part_nums_sntp)) ? '' : str
+         ((block.level.to_i == 1 && !$chap_nums_sntp) || (block.level.to_i == 0 && !part_nums)) ? '' : str
     else
       nil
     end
   end
   
-  def convert_block_nr nr, level
-    my_char = String.new($styles_arr_sntp[level])
+  def convert_block_nr nr, level, styles_arr
+    my_char = String.new(styles_arr[level])
     if my_char == 'i' || my_char == 'I'
       big_roman = int_to_roman_str nr
       return (my_char == 'i' ? big_roman.downcase : big_roman)

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -87,7 +87,9 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   
   def convert_block_nr nr, level
     my_char = String.new($styles_arr_sntp[level])
-    # You COULD, if you wish, put an 'if' here which checks whether my_char is a Roman numeral and, if so, calls a separate function to convert the number to the appropriate Roman-numeral format (uppercase or lowercase), but if not, runs this loop:
+    # You COULD, if you wish, put an 'if' here which checks whether my_char is a 'I' or an 'i' and, if so, calls some function
+	# (based on, e.g., https://codequizzes.wordpress.com/2013/10/27/converting-an-integer-to-a-roman-numeral/ )
+	#  to convert nr to the appropriate Roman-numeral format (uppercase or lowercase)--but if not, runs this loop:
     for i in 1..(nr - 1)
       my_char.succ!
     end

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -16,22 +16,23 @@ $level_previous = 0  # pertinent only where someone has, in their sequence, wron
 class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   def process document
     return unless (document.basebackend? 'docbook') && document.blocks?
-    process_blocks document
+    levels = document.attributes['sectnumlevels']
+    process_blocks document, levels
     nil
   end
 
-  def process_blocks node
+  def process_blocks node, levels
     node.blocks.each do |block|
       if block.context == :section && (defined? block.title)
-        block.title = "#{concat_sec_nr block}#{block.title}"
-        process_blocks block if block.blocks?
+        block.title = "#{concat_sec_nr block, levels}#{block.title}"
+        process_blocks block, levels if block.blocks?
         nil
       end
     end
   end
   
-  def concat_sec_nr block
-    if block.numbered && (defined? block.level)
+  def concat_sec_nr block, levels
+    if block.numbered && (defined? block.level) && block.level.to_i <= levels.to_i
       if block.level.to_i > $level_previous + 1
         for i in ($level_previous + 1)..block.level.to_i
           $levels_arr[i - 1] = '1'

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -33,6 +33,11 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   
   def concat_sec_nr block, levels
     if block.numbered && (defined? block.level) && block.level.to_i <= levels.to_i
+      if block.level.to_i > $levels_arr.length
+        for i in ($levels_arr.length)..block.level.to_i
+          $levels_arr.push '0'
+        end
+      end
       if block.level.to_i > $level_previous + 1
         for i in ($level_previous + 1)..block.level.to_i
           $levels_arr[i - 1] = '1'

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -8,7 +8,7 @@ $punct_sntp = '.'         # punctuation between levels' numbers: e.g., '.' yield
 $nr_suffix_sntp = '. '    # punctuation after the number and before the chapter's/section's title
 $chap_nums_sntp = true    # enables/disables chapter-labeling
 $part_nums_sntp = true    # enables/disables part-labeling
-$chap_nr_in_sec_nr_sntp = false   # in book, starts sec-labels' nrs with chapter's number (whether or not chap-labeling enabled)
+$chap_nr_in_sec_nr_sntp = true   # in book, starts sec-labels' nrs with chapter's number (whether or not chap-labeling enabled)
 $part_nr_in_chap_nr_sntp = false  # in book, starts chap.-labels' nrs with part's number (whether or not part-labeling enabled)
 $part_nr_in_sec_nr_sntp = true # comes into play only if $part_nr_in_chap_nr_sntp = true AND $chap_nr_in_sec_nr_sntp = true
 $part_nr_prefix_sntp = 'Part '

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -22,31 +22,31 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
 
   def process_blocks node
     node.blocks.each do |block|
-	  if block.context == :section && (defined? block.title)
-	    block.title = "#{concat_sec_nr block}#{block.title}"
-	    process_blocks block if block.blocks?
-	    nil
-	  end
-	end
+      if block.context == :section && (defined? block.title)
+        block.title = "#{concat_sec_nr block}#{block.title}"
+        process_blocks block if block.blocks?
+        nil
+      end
+    end
   end
   
   def concat_sec_nr block
-	if block.numbered && (defined? block.level)
+    if block.numbered && (defined? block.level)
       if block.level.to_i > $level_previous + 1
-	    for i in ($level_previous + 1)..block.level.to_i
-		  $levels_arr[i - 1] = '0'
-		end
-	  end
-	  $level_previous = block.level.to_i
-	  $levels_arr[block.level.to_i - 1] = block.number.to_s
-	  str = $nr_prefix + $levels_arr[0]
-	  for i in 1..(block.level.to_i - 1)
-	    str += "#{$punct}#{$levels_arr[i]}"
-	  end
-	  str += $nr_suffix
-	else
-	  nil
-	end
+        for i in ($level_previous + 1)..block.level.to_i
+          $levels_arr[i - 1] = '0'
+        end
+      end
+      $level_previous = block.level.to_i
+      $levels_arr[block.level.to_i - 1] = block.number.to_s
+      str = $nr_prefix + $levels_arr[0]
+      for i in 1..(block.level.to_i - 1)
+        str += "#{$punct}#{$levels_arr[i]}"
+      end
+      str += $nr_suffix
+    else
+      nil
+    end
   end
 end
 

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -4,16 +4,18 @@ include Asciidoctor
 
 # Mess with these values to your heart's content:
 
-$punct = '.'         # punctuation between levels' numbers: e.g., '.' yields '1.3.2'
-$nr_suffix = '. '    # punctuation after the number and before the chapter's/section's title
-$chap_nums = true    # enables/disables chapter-numbering
-$chap_nr_prefix = 'Chapter '
-$sec_nr_prefix = ''
+$punct_sntp = '.'         # punctuation between levels' numbers: e.g., '.' yields '1.3.2'
+$nr_suffix_sntp = '. '    # punctuation after the number and before the chapter's/section's title
+$chap_nums_sntp = true    # enables/disables chapter-numbering
+$chap_nr_prefix_sntp = 'Chapter '
+$sec_nr_prefix_sntp = ''
+# The style you want at each level (first level is chapters; each level's style must be 'A', 'a', or '1'):
+$styles_arr_sntp = [ '1', '1', '1', '1', '1', '1', '1', '1', '1', '1' ]
 
 # DON'T mess with these values:
 
-$levels_arr = [ '0', '0', '0', '0', '0', '0', '0', '0', '0', '0' ]
-$level_previous = 0  # pertinent only where someone has, in their sequence, wrongly jumped two rather than only one level deeper
+$levels_arr_sntp = [ '0', '0', '0', '0', '0', '0', '0', '0', '0', '0' ]
+$level_previous_sntp = 0  # pertinent only where someone has, in their sequence, wrongly jumped two rather than only one level deeper
 
 class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   def process document
@@ -36,29 +38,37 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   
   def concat_sec_nr block, levels, dtype
     if block.numbered && (defined? block.level) && (!(levels) || block.level.to_i <= levels.to_i)
-      if block.level.to_i > $levels_arr.length
-        for i in ($levels_arr.length)..block.level.to_i
-          $levels_arr.push '0'
+      if block.level.to_i > $levels_arr_sntp.length
+        for i in ($levels_arr_sntp.length)..block.level.to_i
+          $levels_arr_sntp.push '0'
         end
       end
-      if block.level.to_i > $level_previous + 1
-        for i in ($level_previous + 1)..block.level.to_i
-          $levels_arr[i - 1] = '1'
+      if block.level.to_i > $level_previous_sntp + 1
+        for i in ($level_previous_sntp + 1)..block.level.to_i
+          $levels_arr_sntp[i - 1] = $styles_arr_sntp[i - 1]
         end
       end
-      $level_previous = block.level.to_i
-      $levels_arr[block.level.to_i - 1] = block.number.to_s
-      pref = (dtype && dtype == 'book' && block.level.to_i == 1) ? $chap_nr_prefix : \
-          ( block.level.to_i > 0 ? $sec_nr_prefix : '')
-      str = pref + $levels_arr[0]
+      $level_previous_sntp = block.level.to_i
+      $levels_arr_sntp[block.level.to_i - 1] = convert_block_nr block.number, block.level.to_i
+      pref = (dtype && dtype == 'book' && block.level.to_i == 1) ? $chap_nr_prefix_sntp : \
+          ( block.level.to_i > 0 ? $sec_nr_prefix_sntp : '')
+      str = pref + $levels_arr_sntp[0]
       for i in 1..(block.level.to_i - 1)
-        str += "#{$punct}#{$levels_arr[i]}"
+        str += "#{$punct_sntp}#{$levels_arr_sntp[i]}"
       end
-      str += $nr_suffix
-      ($chap_nums || !dtype || dtype != 'book' || block.level.to_i != 1) ? str : ''
+      str += $nr_suffix_sntp
+      ($chap_nums_sntp || !dtype || dtype != 'book' || block.level.to_i != 1) ? str : ''
     else
       nil
     end
+  end
+  
+  def convert_block_nr nr, level
+    my_char = String.new($styles_arr_sntp[level - 1])
+    for i in 1..(nr - 1)
+      my_char.succ!
+    end
+    return my_char
   end
 end
 

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -34,7 +34,7 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
     if block.numbered && (defined? block.level)
       if block.level.to_i > $level_previous + 1
         for i in ($level_previous + 1)..block.level.to_i
-          $levels_arr[i - 1] = '0'
+          $levels_arr[i - 1] = '1'
         end
       end
       $level_previous = block.level.to_i

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -9,7 +9,7 @@ $nr_suffix_sntp = '. '    # punctuation after the number and before the chapter'
 $chap_nums_sntp = true    # enables/disables chapter-numbering
 $chap_nr_prefix_sntp = 'Chapter '
 $sec_nr_prefix_sntp = ''
-# The style you want at each level (first level is chapters; each level's style must be 'A', 'a', or '1'):
+# The style you want at each level (first level is chapters; each level's style must be 'A', 'a', or '1'; add more if you need):
 $styles_arr_sntp = [ '1', '1', '1', '1', '1', '1', '1', '1', '1', '1' ]
 
 # DON'T mess with these values:

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -16,7 +16,7 @@ $level_previous = 0  # pertinent only where someone has, in their sequence, wron
 class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   def process document
     return unless (document.basebackend? 'docbook') && document.blocks?
-    levels = document.attributes['sectnumlevels']
+    levels = (defined? document.attributes['sectnumlevels']) ? document.attributes['sectnumlevels'] : nil
     process_blocks document, levels
     nil
   end
@@ -32,7 +32,7 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   end
   
   def concat_sec_nr block, levels
-    if block.numbered && (defined? block.level) && block.level.to_i <= levels.to_i
+    if block.numbered && (defined? block.level) && (!(levels) || block.level.to_i <= levels.to_i)
       if block.level.to_i > $levels_arr.length
         for i in ($levels_arr.length)..block.level.to_i
           $levels_arr.push '0'

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -8,14 +8,14 @@ $punct_sntp = '.'         # punctuation between levels' numbers: e.g., '.' yield
 $nr_suffix_sntp = '. '    # punctuation after the number and before the chapter's/section's title
 $chap_nums_sntp = true    # enables/disables chapter-labeling
 $part_nums_sntp = true    # enables/disables part-labeling
-$chap_nr_in_sec_nr_sntp = true   # in book, starts sec-labels' nrs with chapter's number (whether or not chap-labeling enabled)
+$chap_nr_in_sec_nr_sntp = false   # in book, starts sec-labels' nrs with chapter's number (whether or not chap-labeling enabled)
 $part_nr_in_chap_nr_sntp = false  # in book, starts chap.-labels' nrs with part's number (whether or not part-labeling enabled)
 $part_nr_in_sec_nr_sntp = true # comes into play only if $part_nr_in_chap_nr_sntp = true AND $chap_nr_in_sec_nr_sntp = true
 $part_nr_prefix_sntp = 'Part '
 $chap_nr_prefix_sntp = 'Chapter '
 $sec_nr_prefix_sntp = ''
-# The style you want at each level (level 0 is PARTS, 1 CHAPS; set each level's style to 'A', 'a', or '1'; add more if you need):
-$styles_arr_sntp = [ '1', '1', '1', '1', '1', '1', '1', '1', '1', '1' ]
+# The style you want at each level (level 0 is PARTS, 1 CHAPS; set each style to 'A','a','I','i', or '1'; add more if you need):
+$styles_arr_sntp = [ 'I', '1', '1', '1', '1', '1', '1', '1', '1', '1' ]
 
 # DON'T mess with these values:
 
@@ -87,13 +87,47 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   
   def convert_block_nr nr, level
     my_char = String.new($styles_arr_sntp[level])
-    # You COULD, if you wish, put an 'if' here which checks whether my_char is a 'I' or an 'i' and, if so, calls some function
-    # (based on, e.g., https://codequizzes.wordpress.com/2013/10/27/converting-an-integer-to-a-roman-numeral/ )
-    #  to convert nr to the appropriate Roman-numeral format (uppercase or lowercase)--but if not, runs this loop:
-    for i in 1..(nr - 1)
-      my_char.succ!
+    if my_char == 'i' || my_char == 'I'
+      big_roman = int_to_roman_str nr
+      return (my_char == 'i' ? big_roman.downcase : big_roman)
+    else
+      for i in 1..(nr - 1)
+        my_char.succ!
+      end
+      return my_char
     end
-    return my_char
+  end
+  
+  def int_to_roman_str nr
+    # (Thanks, https://codequizzes.wordpress.com/2013/10/27/converting-an-integer-to-a-roman-numeral/ !)
+    if nr > 3999 then return 'BLAP!!--NrTooBigForRomanNumFunction:-/' end
+    map_of_roman = {
+      1000 => "M",
+      900 => "CM",
+      500 => "D",
+      400 => "CD",
+      100 => "C",
+      90 => "XC",
+      50 => "L",
+      40 => "XL",
+      10 => "X",
+      9 => "IX",
+      5 => "V",
+      4 => "IV",
+      1 => "I"
+    }
+    result = ''
+
+    if nr == 0
+      result
+    else
+      map_of_roman.keys.each do |divisor|
+        quotient, modulus = nr.divmod(divisor)
+        result << map_of_roman[divisor] * quotient
+        nr = modulus
+      end
+      result
+    end
   end
 end
 

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -88,8 +88,8 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
   def convert_block_nr nr, level
     my_char = String.new($styles_arr_sntp[level])
     # You COULD, if you wish, put an 'if' here which checks whether my_char is a 'I' or an 'i' and, if so, calls some function
-	# (based on, e.g., https://codequizzes.wordpress.com/2013/10/27/converting-an-integer-to-a-roman-numeral/ )
-	#  to convert nr to the appropriate Roman-numeral format (uppercase or lowercase)--but if not, runs this loop:
+    # (based on, e.g., https://codequizzes.wordpress.com/2013/10/27/converting-an-integer-to-a-roman-numeral/ )
+    #  to convert nr to the appropriate Roman-numeral format (uppercase or lowercase)--but if not, runs this loop:
     for i in 1..(nr - 1)
       my_char.succ!
     end

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -14,7 +14,7 @@ $part_nr_in_sec_nr_sntp = true # comes into play only if $part_nr_in_chap_nr_snt
 $part_nr_prefix_sntp = 'Part '
 $chap_nr_prefix_sntp = 'Chapter '
 $sec_nr_prefix_sntp = ''
-# The style you want at each level (level 0 is PARTS, 1 CHAPS; set each style to 'A','a','I','i', or '1'; add more if you need):
+# The style you want at each level (level 0 is PARTS, 1 CHAPS; set styles to 'A','a','I','i', or '1'; add levels if you need to):
 $styles_arr_sntp = [ 'I', '1', '1', '1', '1', '1', '1', '1', '1', '1' ]
 
 # DON'T mess with these values:

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -1,0 +1,52 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include Asciidoctor
+
+# Mess with these values to your heart's content:
+
+$punct = '.'
+$nr_suffix = '. '
+$nr_prefix = ''
+
+# DON'T mess with these values:
+
+$levels_arr = [ '0', '0', '0', '0', '0', '0', '0', '0', '0', '0' ]
+$level_previous = 0  # pertinent only where someone has, in their sequence, wrongly jumped two rather than only one level deeper
+
+class SectionNumbersTreeProcessor < Extensions::TreeProcessor
+  def process document
+    return unless (document.basebackend? 'docbook') && document.blocks?
+    process_blocks document
+    nil
+  end
+
+  def process_blocks node
+    node.blocks.each do |block|
+	  if block.context == :section && (defined? block.title)
+	    block.title = "#{concat_sec_nr block}#{block.title}"
+	    process_blocks block if block.blocks?
+	    nil
+	  end
+	end
+  end
+  
+  def concat_sec_nr block
+	if block.numbered && (defined? block.level)
+      if block.level.to_i > $level_previous + 1
+	    for i in ($level_previous + 1)..block.level.to_i
+		  $levels_arr[i - 1] = '0'
+		end
+	  end
+	  $level_previous = block.level.to_i
+	  $levels_arr[block.level.to_i - 1] = block.number.to_s
+	  str = $nr_prefix + $levels_arr[0]
+	  for i in 1..(block.level.to_i - 1)
+	    str += "#{$punct}#{$levels_arr[i]}"
+	  end
+	  str += $nr_suffix
+	else
+	  nil
+	end
+  end
+end
+

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -6,8 +6,8 @@ include Asciidoctor
 
 $punct_sntp = '.'         # punctuation between levels' numbers: e.g., '.' yields '1.3.2'
 $nr_suffix_sntp = '. '    # punctuation after the number and before the chapter's/section's title
-$chap_nums_sntp = true    # enables/disables chapter-labeling
-$part_nums_sntp = true    # enables/disables part-labeling
+$chap_nums_sntp = true    # enables/disables chapter-labeling--in a book
+$part_nums_sntp = true    # enables/disables part-labeling--in a book
 $chap_nr_in_sec_nr_sntp = true   # in book, starts sec-labels' nrs with chapter's number (whether or not chap-labeling enabled)
 $part_nr_in_chap_nr_sntp = false  # in book, starts chap.-labels' nrs with part's number (whether or not part-labeling enabled)
 $part_nr_in_sec_nr_sntp = true # comes into play only if $part_nr_in_chap_nr_sntp = true AND $chap_nr_in_sec_nr_sntp = true

--- a/lib/section-numbers-tree-processor/extension.rb
+++ b/lib/section-numbers-tree-processor/extension.rb
@@ -61,7 +61,8 @@ class SectionNumbersTreeProcessor < Extensions::TreeProcessor
       end
       $level_previous_sntp = block.level.to_i
       # Convert the block.number to the style you specified for this level; and store it in levels_arr_sntp[block.level.to_i] :
-      $levels_arr_sntp[block.level.to_i] = convert_block_nr block.number.to_s.tr('A-I', '1-9').to_i, block.level.to_i, styles_arr
+      block_nr_as_int = ( block.sectname == 'appendix' ? ( block.number.unpack('c')[0] - 64 ) : block.number )
+      $levels_arr_sntp[block.level.to_i] = convert_block_nr block_nr_as_int, block.level.to_i, styles_arr
       # Apply any appropriate prefix:
       pref = (dtype && dtype == 'book' && block.level.to_i == 1) ? $chap_nr_prefix_sntp : \
           ( (dtype && dtype == 'book' && block.level.to_i == 0) ? $part_nr_prefix_sntp : \

--- a/lib/section-numbers-tree-processor/sample.adoc
+++ b/lib/section-numbers-tree-processor/sample.adoc
@@ -1,6 +1,10 @@
 = big deal
 :sectnums:
+:partnums:
 :sectnumlevels: 4
+:doctype: book
+
+= A first big deal
 
 == Section
 
@@ -29,6 +33,9 @@ content
 === Subsection back to just tantalizing
 
 content for sure
+
+= Here's another big deal!
+Oh indeed.
 
 == Section back to just tantalizing
 
@@ -60,5 +67,5 @@ oh yea
 === Subsection oh so really tantalizing
 oh yea
 
-====== Subsection so MUCH deeper, indeed suddenly 5 levels deep!
+====== Subsection so MUCH deeper, indeed suddenly 5 levels deep--COUNTING the chap.nr as 1, if doctype is 'book'!!
 oh yea

--- a/lib/section-numbers-tree-processor/sample.adoc
+++ b/lib/section-numbers-tree-processor/sample.adoc
@@ -1,10 +1,10 @@
 = big deal
 :sectnums:
+:sectnumlevels: 4
 
 == Section
 
 content
-
 
 === Subsection Most Tantalizing
 
@@ -21,7 +21,7 @@ content
 content
 
 :sectnums!:
-===== Subsection the most tantalizing YET
+===== Subsection the most tantalizing YET, but in a non-section-numbering part!
 
 content
 
@@ -42,15 +42,15 @@ oh yea
 
 content oh yes
 
-==== Yet Another Subsection the most tantalizing YET
+===== Yet Another Subsection the most tantalizing YET
 
 content oh yes
+
+===== Another Subsection for sure the most tantalizing YET
 
 === Subsection back to just amazingly tantalizing
 
 content for sure
-
-==== Another Subsection for sure the most tantalizing YET
 
 content oh yes
 
@@ -58,4 +58,7 @@ content oh yes
 oh yea
 
 === Subsection oh so really tantalizing
+oh yea
+
+====== Subsection so MUCH deeper, indeed suddenly 5 levels deep!
 oh yea

--- a/lib/section-numbers-tree-processor/sample.adoc
+++ b/lib/section-numbers-tree-processor/sample.adoc
@@ -69,3 +69,21 @@ oh yea
 
 ====== Subsection so MUCH deeper, indeed suddenly 5 levels deep--COUNTING the chap.nr as 1, if doctype is 'book'!!
 oh yea
+
+= A third big deal
+
+What I said
+
+== Thinking of things
+
+No, not what I said
+
+== Going further
+
+Ah, now, that's what I'm talking {rsquo}bout.
+
+= A final big deal
+
+== Are we au fait with Roman numerals, yet, my chilluns?
+
+Oh, yessss

--- a/lib/section-numbers-tree-processor/sample.adoc
+++ b/lib/section-numbers-tree-processor/sample.adoc
@@ -48,9 +48,9 @@ content oh yes
 
 ===== Another Subsection for sure the most tantalizing YET
 
-=== Subsection back to just amazingly tantalizing
-
 content for sure
+
+=== Subsection back to just amazingly tantalizing
 
 content oh yes
 

--- a/lib/section-numbers-tree-processor/sample.adoc
+++ b/lib/section-numbers-tree-processor/sample.adoc
@@ -1,0 +1,61 @@
+= big deal
+:sectnums:
+
+== Section
+
+content
+
+
+=== Subsection Most Tantalizing
+
+----
+content
+----
+
+==== Subsection Even More Tantalizing
+
+content
+
+==== ANOTHER Subsection Even More Tantalizing
+
+content
+
+:sectnums!:
+===== Subsection the most tantalizing YET
+
+content
+
+:sectnums:
+=== Subsection back to just tantalizing
+
+content for sure
+
+== Section back to just tantalizing
+
+oh yea
+
+=== Subsection just tantalizing
+
+oh yea
+
+==== Another Subsection the most tantalizing YET
+
+content oh yes
+
+==== Yet Another Subsection the most tantalizing YET
+
+content oh yes
+
+=== Subsection back to just amazingly tantalizing
+
+content for sure
+
+==== Another Subsection for sure the most tantalizing YET
+
+content oh yes
+
+== Subsection really really tantalizing
+oh yea
+
+=== Subsection oh so really tantalizing
+oh yea


### PR DESCRIPTION
Allows you to control your DocBook section numbering from within AsciiDoc, with your sectnums and leveloffset attributes (just like they work with the HTML5 backend). Control over styles--at each level--and more. Updated to work with Asciidoctor 1.5.7, including Parts-numbering.

This extension was inspired by the Asciidoctor discussion topic http://discuss.asciidoctor.org/asciidoctor-fopub-tp6285.html