### PR TITLE
Fix error when using [colophon] section with sectnumoffset

### DIFF
--- a/lib/sectnumoffset-treeprocessor.rb
+++ b/lib/sectnumoffset-treeprocessor.rb
@@ -15,6 +15,7 @@ Extensions.register do
       if (document.attr? 'sectnums') && (sectnumoffset = (document.attr 'sectnumoffset', 0).to_i) > 0
         ((document.find_by context: :section) || []).each do |sect|
           # FIXME use filter block once Asciidoctor >= 1.5.3 is available
+          next unless sect.sectname != 'colophon'
           next unless sect.level == 1
           sect.number += sectnumoffset
         end

--- a/lib/sectnumoffset-treeprocessor/sample.adoc
+++ b/lib/sectnumoffset-treeprocessor/sample.adoc
@@ -1,3 +1,10 @@
+= Title
+
+[colophon]
+== Colophon Section
+
+colophon content
+
 == Section
 
 content


### PR DESCRIPTION
Script aborted when adoc file includes [colophon] section because that case sectnumber was nil.