### PR TITLE
Fixed: removed navigate to top of doc when link was clicked

### DIFF
--- a/lib/view-result-docinfoprocessor/extension.rb
+++ b/lib/view-result-docinfoprocessor/extension.rb
@@ -49,7 +49,6 @@ document.addEventListener('DOMContentLoaded', function() {
     resultNode.style.display = 'none';
     var viewLink = document.createElement('a');
     viewLink.className = 'view-result';
-    viewLink.href = '#';
     viewLink.appendChild(document.createTextNode('[ view result ]'));
     resultNode.previousElementSibling.querySelector('.title').appendChild(viewLink);
     viewLink.addEventListener('click', toggle_result_block);

--- a/lib/view-result-docinfoprocessor/sample.adoc
+++ b/lib/view-result-docinfoprocessor/sample.adoc
@@ -11,3 +11,25 @@
 * hidden till clicked
 * hidden till clicked 2
 ====
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ullamcorper malesuada sapien quis pulvinar. In sit amet turpis vitae arcu pretium bibendum at vel tortor. Quisque pellentesque non lorem eu pellentesque. In auctor augue eu risus pellentesque, ut fermentum arcu sollicitudin. Maecenas maximus pretium felis ut maximus. Donec condimentum bibendum tortor id varius. Nam dictum pharetra nunc, in dignissim neque consequat et.
+
+Aliquam quam tellus, mattis sit amet ex nec, pretium finibus sapien. Nulla vitae nisl iaculis, gravida libero id, imperdiet mi. Vivamus fermentum tortor ac arcu lacinia, a iaculis tortor luctus. Phasellus interdum orci in diam egestas suscipit. Aliquam erat volutpat. Donec bibendum risus sed condimentum porttitor. Quisque at auctor sapien. Nullam quis tortor maximus, suscipit massa ac, tincidunt purus.
+
+Donec sodales porta lectus. Praesent in ex at dolor lobortis volutpat. Quisque dignissim turpis eget magna porta, in tempor arcu convallis. Sed at lectus malesuada ante consequat viverra non quis purus. Sed porttitor eleifend eleifend. In hac habitasse platea dictumst. Aliquam congue ultrices ornare. Nulla eget laoreet nulla. Suspendisse gravida, sapien ut tristique cursus, enim odio euismod mauris, in suscipit augue lectus sit amet enim. Sed vehicula eu purus non consectetur. Vivamus id molestie felis. Duis vitae sapien feugiat, facilisis nunc a, suscipit elit. Vestibulum lacinia libero a ex placerat maximus. Donec massa enim, accumsan sed magna vel, aliquet faucibus nisl. In laoreet diam eget congue lacinia. Nulla fringilla leo nisi, sit amet malesuada ligula dignissim sed.
+
+Duis hendrerit, mauris id sagittis luctus, sapien ipsum ultrices magna, nec vestibulum metus est et enim. Maecenas porta mauris eget nunc cursus, sit amet porta sapien rhoncus. Sed varius, ipsum non fringilla egestas, diam augue bibendum felis, et cursus nulla mi tempus libero. Aliquam vitae ligula sollicitudin risus molestie ultrices non eu nunc. Donec gravida porttitor consequat. Phasellus eu nisi in metus tincidunt rhoncus. Cras non vulputate dui.
+
+Pellentesque diam sem, consequat ut sapien id, mollis placerat justo. Quisque hendrerit nec nisl vel malesuada. Etiam dolor magna, egestas scelerisque fermentum non, varius ac metus. Praesent at mauris pulvinar, tristique leo eu, mattis enim. Proin in enim ac justo euismod varius non ornare urna. Nunc finibus mauris sed est sodales dignissim. Aenean faucibus, ante sed laoreet aliquam, enim massa blandit mauris, nec ornare urna magna id justo. Etiam et arcu sapien. Etiam a magna sodales, fringilla nulla eget, porta massa. Aenean vitae vehicula enim, vel aliquet tortor. Nulla euismod justo sapien, quis ornare nunc tincidunt eu.
+
+.This will have a link next to it
+----
+* always displayed
+* always displayed 2
+----
+
+[.result]
+====
+* hidden till clicked
+* hidden till clicked 2
+====


### PR DESCRIPTION
When generated URL was clicked the browser would jump to the top of the page because of the "href=#" in the link. Removed href and added some ipsum lorem to the sample file so when opened in browser with scrollbar active you should no longer jump to top of page.