### PR TITLE
An Extension for Defining Additional Replacements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -58,6 +58,9 @@ NOTE: The registration file (e.g., emoji-inline-macro.rb) goes in the [path]_lib
 
 The following extensions are available in the lab.
 
+AdditionalReplacementsPostprocessor, link:lib/additional-replacements-postprocessor.rb.rb[]::
+Automatically replaces certain sequences of characters with better typography (e.g. adds cedilla descenders to the C's in "`facade`" and "`soupcon,`" punctuates "`naivite`" with an umlaut over the first I and an acute over the E, and converts 1/4, 1/2, and 3/4 to single characters).
+
 AutoXrefTreeprocessor, link:lib/autoxref-treeprocessor.rb[]::
 Refers images, tables, listings, sections by their numbers.
 

--- a/lib/additional-replacements-postprocessor.rb
+++ b/lib/additional-replacements-postprocessor.rb
@@ -3,14 +3,14 @@ require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
 include Asciidoctor
 
 class AdditionalReplacementsPostprocessor < Extensions::Postprocessor
-  MathSymbolPatterns = [/(?<!\\)\(o\)/, /(?<![\\0-9])1\/2(?![0-9])/, /(?<![\\0-9])1\/4(?![0-9])/, /(?<![\\0-9])3\/4(?![0-9])/]
-  MathSymbols = ['&#176;', '&#189;', '&#188;', '&#190;']
+  MathSymbolPatterns = [/(?<![\\0-9])1\/2(?![0-9])/, /(?<![\\0-9])1\/4(?![0-9])/, /(?<![\\0-9])3\/4(?![0-9])/]
+  MathSymbols = ['&#189;', '&#188;', '&#190;']
 
-  MathSymbolPatternsEscaped = [/\\\(o\)/, /\\1\/2/, /\\1\/4/, /\\3\/4/]
-  MathSymbolsEscaped = ['(o)', '1/2', '1/4', '3/4']
+  MathSymbolPatternsEscaped = [/\\1\/2/, /\\1\/4/, /\\3\/4/]
+  MathSymbolsEscaped = ['1/2', '1/4', '3/4']
 
-  AcuteWordPatterns = [/\bSaute/, /\bsaute/, /\bDecor\b/, /\bdecor\b/, /\bCliche/, /\bcliche/, /\bEntree/, /\bentree/, /\bTouche\b/, /\btouche\b/]
-  AcuteWords = ['Saut&#233;', 'saut&#233;', 'D&#233;cor', 'd&#233;cor', 'Clich&#233;', 'clich&#233;', 'Entr&#233;e', 'entr&#233;e', 'Touch&#233;', 'touch&#233;']
+  AcuteWordPatterns = [/\bSaute/, /\bsaute/, /\bDecor\b/, /\bdecor\b/, /\bCliche/, /\bcliche/, /\bEntree/, /\bentree/, /\bTouche\b/, /\btouche\b/, /\bRisque\b/, /\brisque\b/]
+  AcuteWords = ['Saut&#233;', 'saut&#233;', 'D&#233;cor', 'd&#233;cor', 'Clich&#233;', 'clich&#233;', 'Entr&#233;e', 'entr&#233;e', 'Touch&#233;', 'touch&#233;', 'Risqu&#233;', 'risqu&#233;']
 
   CedillaWordPatterns = [/\bFacade/, /\bfacade/, /\bSoupcon/, /\bsoupcon/]
   CedillaWords = ['Fa&#231;ade', 'fa&#231;ade', 'Soup&#231;on', 'soup&#231;on']

--- a/lib/additional-replacements-postprocessor.rb
+++ b/lib/additional-replacements-postprocessor.rb
@@ -1,0 +1,36 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include Asciidoctor
+
+class AdditionalReplacementsPostprocessor < Extensions::Postprocessor
+  MathSymbolPatterns = [/(?<!\\)\(o\)/, /(?<![\\0-9])1\/2(?![0-9])/, /(?<![\\0-9])1\/4(?![0-9])/, /(?<![\\0-9])3\/4(?![0-9])/]
+  MathSymbols = ['&#176;', '&#189;', '&#188;', '&#190;']
+
+  MathSymbolPatternsEscaped = [/\\\(o\)/, /\\1\/2/, /\\1\/4/, /\\3\/4/]
+  MathSymbolsEscaped = ['(o)', '1/2', '1/4', '3/4']
+
+  AcuteWordPatterns = [/\bSaute/, /\bsaute/, /\bDecor\b/, /\bdecor\b/, /\bCliche/, /\bcliche/, /\bEntree/, /\bentree/, /\bTouche\b/, /\btouche\b/]
+  AcuteWords = ['Saut&#233;', 'saut&#233;', 'D&#233;cor', 'd&#233;cor', 'Clich&#233;', 'clich&#233;', 'Entr&#233;e', 'entr&#233;e', 'Touch&#233;', 'touch&#233;']
+
+  CedillaWordPatterns = [/\bFacade/, /\bfacade/, /\bSoupcon/, /\bsoupcon/]
+  CedillaWords = ['Fa&#231;ade', 'fa&#231;ade', 'Soup&#231;on', 'soup&#231;on']
+
+  UmlautWordPatterns = [/\bNaive/, /\bnaive/, /\bNaivite/, /\bnaivite/]
+  UmlautWords = ['Na&#239;ve', 'na&#239;ve', 'Na&#239;vit&#233;', 'na&#239;vit&#233;']
+
+  CombinedPatterns = MathSymbolPatterns + MathSymbolPatternsEscaped + AcuteWordPatterns + CedillaWordPatterns + UmlautWordPatterns
+  CombinedReplacements = MathSymbols + MathSymbolsEscaped + AcuteWords + CedillaWords + UmlautWords
+
+  def process document, output
+    CombinedPatterns.zip(CombinedReplacements).each do |pattern, replacement|
+      output = output.gsub pattern, replacement
+    end
+    output
+  end
+end
+
+Extensions.register :additionalreplacements do |document|
+  document.postprocessor AdditionalReplacementsPostprocessor
+end
+
+

--- a/lib/additional-replacements-postprocessor/sample.adoc
+++ b/lib/additional-replacements-postprocessor/sample.adoc
@@ -1,0 +1,31 @@
+= AsciiDoctor Replacements Example
+
+This is a sample file that demonstrates the `additional-replacements-postprocessor.rb` AsciiDoctor extension
+
+CLI Usage:
+
+......................
+$ asciidoctor -r ./lib/additional-replacements-postprocessor.rb ./lib/additional-replacements-postprocessor/sample.adoc
+......................
+
+Use \(o) for a *degree symbol*, as in "`The temperature hit a record low of -37(o)F.`"
+
+For the *fractions* half (1/2), one-quarter (1/4), and three-quarters (3/4), use \1/2, \1/4, and \3/4, respectively.
+
+The following words should all have an *acutes*:
+Saute, saute, sauted, sauteing.
+Decor, decor.
+Cliche, cliche, cliched, cliches.
+Entree, entree, entrees.
+Touche, touche.
+
+The following words should all have *cedillas*:
+Facade, facade, facades.
+Soupcon, soupcon.
+
+The following words should all have *umlauts*:
+Naive, naive.
+
+The following words should have both an *umlaut* and an *acute*:
+Naivite, naivite.
+

--- a/lib/additional-replacements-postprocessor/sample.adoc
+++ b/lib/additional-replacements-postprocessor/sample.adoc
@@ -1,4 +1,5 @@
 = AsciiDoctor Replacements Example
+:ditto: &#34;
 
 This is a sample file that demonstrates the `additional-replacements-postprocessor.rb` AsciiDoctor extension
 
@@ -8,16 +9,16 @@ CLI Usage:
 $ asciidoctor -r ./lib/additional-replacements-postprocessor.rb ./lib/additional-replacements-postprocessor/sample.adoc
 ......................
 
-Use \(o) for a *degree symbol*, as in "`The temperature hit a record low of -37(o)F.`"
 
 For the *fractions* half (1/2), one-quarter (1/4), and three-quarters (3/4), use \1/2, \1/4, and \3/4, respectively.
 
-The following words should all have an *acutes*:
+The following words should all have *acutes*:
 Saute, saute, sauted, sauteing.
 Decor, decor.
 Cliche, cliche, cliched, cliches.
 Entree, entree, entrees.
 Touche, touche.
+Risque, risque.
 
 The following words should all have *cedillas*:
 Facade, facade, facades.
@@ -29,3 +30,33 @@ Naive, naive.
 The following words should have both an *umlaut* and an *acute*:
 Naivite, naivite.
 
+Reminder: AsciiDoctor has many built-in attribute definitions for special symbols.
+(The latter half of this list are so that actual text does not get confused with AsciiDoc syntax.)
+
+[width="100%",cols="5,^2,^2,8",options="header"]
+|===
+^| Symbol                    ^|  Notation     ^|  Becomes     ^| Example
+| Degree                      |  \{deg\}       |  &amp;#176;   | A record low of -37{deg}F.
+| Non-Breaking Space          |  \{nbsp\}      |  &amp;#160;   |
+| Zero-Width Space            |  \{zwsp\}      |  &amp;#8203;  | 
+| Word Joiner                 |  \{wj\}        |  &amp;#8288;  | 
+| Apostrophe (vertical)       |  \{apos\}      |  &amp;#39;    | An example character constant: `{apos}X{apos}`
+| Double Quote (vertical)     |  \{quot\}      |  &amp;#34;    | An example string constant: `{quot}Abc{quot}`
+| Left Single Quote           |  \{lsquo\}     |  &amp;#8216;  | {ldquo}...and then he said {lsquo}Oh yeah?{rsquo}{rdquo}
+| Right Single Quote          |  \{rsquo\}     |  &amp;#8217; ^| {ditto}
+| Left Double Quote           |  \{ldquo\}     |  &amp;#8220; ^| {ditto}
+| Right Double Quote          |  \{rdquo\}     |  &amp;#8221; ^| {ditto}
+| Plus                        |  \{plus\}      |  &amp;#43;    | {plus}
+| Broken Vertical Bar         |  \{brvbar\}    |  &amp;#166;   | {brvbar}
+| Solid Vertical Bar          |  \{vbar\}      |               | {vbar}
+| Ampersand                   |  \{amp\}       |               | {amp}
+| Less Than                   |  \{lt\}        |               | {lt}
+| Greater Than                |  \{gt\}        |               | {gt}
+| Start Square Bracket        |  \{startsb\}   |               | He tweeted, "`Covfefe{startsb}sic{endsb}.`"
+| End Square Bracket          |  \{endsb\}     |              ^| {ditto}
+| Caret                       |  \{caret\}     |               | {caret}
+| Asterisk                    |  \{asterisk\}  |               | {asterisk}
+| Tilde                       |  \{tilde\}     |               | {tilde}
+| Backslash                   |  \{backslash\} |               | {backslash}
+| Back Tick                   |  \{backtick\}  |               | {backtick}
+|===


### PR DESCRIPTION
An AsciiDoctor extension that provides certain additional replacements (of the sort that would have been set in the [Replacements] section of asciidoc.conf when using AsciiDoc Python). This first cut includes (o) for the degree symbol, 1/2, 1/4, 3/4, and a dozen fairly common words that contain acutes, umlauts, and/or cedillas (entree, cliche, soupcon, naive, etc.)