### PR TITLE
Add treeprocessor to change image titles

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,6 +106,9 @@ Adds hardbreaks to the end of all non-empty lines that aren't section titles.
 HighlightTreeprocessor, link:lib/highlight-treeprocessor.rb[]::
 Highlights source blocks using the highlight command.
 
+ImageRefstyleTreeprocessor, link:lib/imagerefstyle-treeprocessor.rb[]::
+Allows custom reference/label/caption style for images (including those output from asciidoctor-diagram) in the form of "Figure `<Chapter.FigureNumber>``.". See also the AutoXrefTreeprocessor for a more sophisticated but similar function.
+
 ImplicitApidocInlineMacro, link:lib/implicit-apidoc-inline-macro.rb[]::
 Adds an inline macro for linking to the Javadoc of a class in the Java EE API.
 

--- a/lib/imagerefstyle-treeprocessor.rb
+++ b/lib/imagerefstyle-treeprocessor.rb
@@ -1,0 +1,37 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include Asciidoctor
+
+DIAGRAM_TYPES = ['a2s', 'actdiag', 'blockdiag', 'ditaa', 'erd', 'graphviz', 'meme', 'mermaid', 'msc', 'nwdiag', 'packetdiag', 'plantuml', 'rackdiag', 'seqdiag', 'shaape', 'svgbob', 'syntrax', 'umlet', 'vega', 'vegalite', 'wavedrom']
+
+Extensions.register do
+  treeprocessor do
+    process do |document|
+      figureNumbers = {}
+      document.find_by(context: :section) {|sect|
+        if sect.level == 1
+          figureNumbers[sect.level] = 0
+          # how to specify multiple contexts better?
+          sect.find_by(context: nil) {|obj|
+
+            # select either images or literal blocks supported by asciidoctor-diagram
+            if (obj.context == :image) || (obj.context == :literal && DIAGRAM_TYPES.include?(obj.attributes['1'])) 
+                
+                figureNumbers[sect.level] += 1
+
+                obj.caption = 'Figure ' + sect.sectnum.to_s + figureNumbers[sect.level].to_s + '. '
+                obj.attributes['reftext'] = obj.caption
+
+                # literal blocks don't usually get titles in the same manner as images
+                if obj.context == :literal && DIAGRAM_TYPES.include?(obj.attributes['1'])
+                    obj.title = obj.caption + obj.title
+                end
+            end
+          }
+          
+        end
+      }
+    end
+    nil
+  end
+end

--- a/lib/imagerefstyle-treeprocessor/sample.adoc
+++ b/lib/imagerefstyle-treeprocessor/sample.adoc
@@ -1,0 +1,56 @@
+:sectnums:
+:sectnumlevels: 3
+:allow-uri-read:
+:uri-asciidoctor-diagram: https://asciidoctor.org/docs/asciidoctor-diagram/  
+= Introduction
+
+This extension changes the titles for images and certain literal blocks used by {uri-asciidoctor-diagram}[asciidoctor-diagram] so they are in the form: "`Figure `<ChapterNum.ItemWithinChapter>``".
+
+Run with something like:
+
+ /usr/bin/asciidoctor -r asciidoctor-diagram -r ./lib/imagerefstyle-treeprocessor.rb ./lib/imagerefstyle-treeprocessor/sample.adoc --trace
+
+== First Chapter
+
+[#somegreatthing]
+.Some Great Thing
+image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[width=500]
+
+
+[#anothergreatthing]
+.Another Great Thing
+image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[width=250]
+
+=== Sub Chapter
+
+[#stillatthesamelevel]
+.Still At The Same Level
+image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[width=125]
+
+Also see <<anothergreatthing>>
+
+== Another chapter
+
+[[ditaa-diagram]]
+[ditaa]
+.Something beautiful
+....
+                   +-------------+
+                   | Asciidoctor |-------+
+                   |   diagram   |       |
+                   +-------------+       | PNG out
+                       ^                 |
+                       | ditaa in        |
+                       |                 v
+ +--------+   +--------+----+    /---------------\
+ |        | --+ Asciidoctor +--> |               |
+ |  Text  |   +-------------+    |   Beautiful   |
+ |Document|   |   !magic!   |    |    Output     |
+ |     {d}|   |             |    |               |
+ +---+----+   +-------------+    \---------------/
+     :                                   ^
+     |          Lots of work             |
+     +-----------------------------------+
+....
+
+Checkout <<ditaa-diagram>>


### PR DESCRIPTION
As requested on [gitter](https://gitter.im/asciidoctor/asciidoctor?at=5e01429ae0131f50c99572e6) by @benritter88

Puts titles in `ChapterNum.FigureNum` notation, hopefully including those produced by asciidoctor-diagram.

Nomenclature is dubious "reference" "label" "caption" ? !

Happy to make changes on review.