### PR TITLE
Add list-of-figures extension

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -124,6 +124,9 @@ Skips the implicit author line below the document title in included documents.
 LicenseUrlDocinfoProcessor, link:lib/license-url-docinfoprocessor.rb[]::
 Adds a link to the license specified by the `license` attribute to the document header.
 
+ListOfFiguresTreeprocessor + ListOfFiguresMacro, link:lib/list-of-figures.rb[]::
+Adds a summary of all image captions
+
 LoremBlockMacro, link:lib/lorem-block-macro.rb[]::
 Generates lorem ipsum text using the Middleman lorem extension. (Requires middleman >= 4.0.0).
 

--- a/lib/list-of-figures.rb
+++ b/lib/list-of-figures.rb
@@ -1,0 +1,7 @@
+RUBY_ENGINE == 'opal' ? (require 'list-of-figures/extension') : (require_relative 'list-of-figures/extension')
+
+Asciidoctor::Extensions.register do
+  block_macro ListOfFiguresMacro
+  tree_processor ListOfFiguresTreeprocessor
+end
+

--- a/lib/list-of-figures/extension.rb
+++ b/lib/list-of-figures/extension.rb
@@ -1,0 +1,71 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+include Asciidoctor
+
+# An macro that adds a list of all figures
+# It only uses images that have a caption!
+#
+# Usage
+"""
+== Test the List of Figures Macro
+
+.The wonderful linux logo
+image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[Linux Logo,100,100]
+
+.Another wikipedia SVG image
+image::https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/SVG_Logo.svg/400px-SVG_Logo.svg.png[SVG,100,100]
+
+=== List of figures
+
+tof::[]
+"""
+ListOfFiguresMacroPlaceholder = %(9d9711cf-0e95-4230-9973-78559fe928db)
+
+# Replaces tof::[] with ListOfFiguresMacroPlaceholder
+class ListOfFiguresMacro < ::Extensions::BlockMacroProcessor
+  use_dsl
+  named :tof
+
+  def process parent, target, attrs
+    create_paragraph parent, ListOfFiguresMacroPlaceholder, {}
+  end
+end
+# Searches for the figures and replaced ListOfFiguresMacroPlaceholder with the list of figures
+# Inspired by https://github.com/asciidoctor/asciidoctor-bibtex/blob/master/lib/asciidoctor-bibtex/extensions.rb#L162
+class ListOfFiguresTreeprocessor < ::Asciidoctor::Extensions::Treeprocessor
+   def process document
+       references_asciidoc = []
+       document.find_by(context: :image).each do |image|
+
+       if image.caption
+           references_asciidoc << %(#{image.caption}#{image.title} +)
+        end
+      end
+      tof_blocks = document.find_by do |b|
+        # for fast search (since most searches shall fail)
+        (b.content_model == :simple) && (b.lines.size == 1) \
+          && (b.lines[0] == ListOfFiguresMacroPlaceholder)
+      end
+      tof_blocks.each do |block|
+        block_index = block.parent.blocks.index do |b|
+          b == block
+        end
+        reference_blocks = parse_asciidoc block.parent, references_asciidoc
+        reference_blocks.reverse.each do |b|
+          block.parent.blocks.insert block_index, b
+        end
+        block.parent.blocks.delete_at block_index + reference_blocks.size
+      end
+    end
+    # This is an adapted version of Asciidoctor::Extension::parse_content,
+    # where resultant blocks are returned as a list instead of attached to
+    # the parent.
+    def parse_asciidoc(parent, content, attributes = {})
+    result = []
+    reader = ::Asciidoctor::Reader.new content
+    while reader.has_more_lines?
+      block = ::Asciidoctor::Parser.next_block reader, parent, attributes
+      result << block if block
+    end
+    result
+    end
+  end

--- a/lib/list-of-figures/sample.adoc
+++ b/lib/list-of-figures/sample.adoc
@@ -1,0 +1,11 @@
+== Test the List of Figures Macro
+
+.The wonderful linux logo
+image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[Linux Logo,100,100]
+
+.Another wikipedia SVG image
+image::https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/SVG_Logo.svg/400px-SVG_Logo.svg.png[SVG,100,100]
+
+=== List of figures
+
+tof::[]


### PR DESCRIPTION
I needed this extension for a project of mine. Additionally, I saw in this [discussion](https://discuss.asciidoctor.org/List-of-tables-figures-td2829.html) and this [issue](https://github.com/asciidoctor/asciidoctor-extensions-lab/issues/111) that I am not the only one, so I thought it would be a nice contribution :)

PS: I only learned Ruby to write this extension, so please be nice.

Sample:
```asciidoc
== Test the List of Figures Macro

.The wonderful linux logo
image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[Linux Logo,100,100]

.Another wikipedia SVG image
image::https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/SVG_Logo.svg/400px-SVG_Logo.svg.png[SVG,100,100]

=== List of figures

tof::[]
```

Rendered:
<img src="https://user-images.githubusercontent.com/39517491/139903592-84e9e6cd-c1a8-45ec-acb7-52f37e366ddc.png" width="400px">
